### PR TITLE
Rename app branding to GorodMore.ru

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <application
-        android:label="m_club"
+        android:label="GorodMore.ru"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -6,16 +6,16 @@
 	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
-	<key>CFBundleDisplayName</key>
-	<string>M Club</string>
+        <key>CFBundleDisplayName</key>
+        <string>GorodMore.ru</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
-	<key>CFBundleName</key>
-	<string>m_club</string>
+        <key>CFBundleName</key>
+        <string>GorodMore.ru</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -37,7 +37,7 @@ class _MyAppState extends State<MyApp> {
     );
 
     return MaterialApp(
-      title: 'M-Club',
+      title: 'GorodMore.ru',
       locale: const Locale('ru'),
       supportedLocales: const [Locale('ru'), Locale('en')],
       localizationsDelegates: GlobalMaterialLocalizations.delegates,

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -1,5 +1,5 @@
 class AppStrings {
-  static const appTitle = 'М-Клуб';
+  static const appTitle = 'GorodMore.ru';
   static const login = 'Войти';
   static const register = 'Регистрация';
 }

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -67,7 +67,7 @@ class _HomeScreenState extends State<HomeScreen> {
         currentIndex: _index,
         onTap: (i) => setState(() => _index = i),
         items: const [
-          BottomNavigationBarItem(icon: Icon(Icons.local_offer), label: 'М-Клуб'),
+          BottomNavigationBarItem(icon: Icon(Icons.local_offer), label: 'GorodMore.ru'),
           BottomNavigationBarItem(icon: Icon(Icons.travel_explore), label: 'Открой ОАЭ!'),
           BottomNavigationBarItem(icon: Icon(Icons.radio), label: 'Радио'),
           BottomNavigationBarItem(icon: Icon(Icons.article), label: 'Новости'),

--- a/lib/features/radio/radio_controller.dart
+++ b/lib/features/radio/radio_controller.dart
@@ -332,7 +332,7 @@ class RadioController extends ChangeNotifier {
         builder: () => RadioAudioHandler(_player),
         config: const AudioServiceConfig(
           androidNotificationChannelId: 'm_club_radio_channel',
-          androidNotificationChannelName: 'M-Club Radio',
+          androidNotificationChannelName: 'GorodMore.ru Radio',
           androidNotificationIcon: 'drawable/radio_notification_icon',
           androidNotificationOngoing: true,
         ),

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1,5 +1,5 @@
 {
-  "appTitle": "M Club",
+  "appTitle": "GorodMore.ru",
   "login": "Login",
   "register": "Register",
   "clubCard": "Club Card",

--- a/lib/l10n/intl_ru.arb
+++ b/lib/l10n/intl_ru.arb
@@ -1,5 +1,5 @@
 {
-  "appTitle": "М-Клуб",
+  "appTitle": "GorodMore.ru",
   "login": "Войти",
   "register": "Регистрация",
   "clubCard": "Клубная карта",


### PR DESCRIPTION
## Summary
- update the Flutter app title, localized resources, and shared string constants to use the GorodMore.ru brand
- refresh user-facing labels in the home navigation and radio notification channel to match the new name
- rename the Android manifest label and iOS display/bundle names to display GorodMore.ru on both platforms

## Testing
- Flutter test *(fails: `flutter` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9a9612de08326bd3d572992aa4fbe