### PR TITLE
Add navigation placeholders for events and poster tabs

### DIFF
--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -14,6 +14,8 @@ class _HomeScreenState extends State<HomeScreen> {
   static const _primary = Color(0xFF182857);
   static const List<Widget> _pages = [
     NewsScreen(),
+    Center(child: Text('События')),
+    Center(child: Text('Афиша')),
   ];
 
   @override
@@ -41,6 +43,8 @@ class _HomeScreenState extends State<HomeScreen> {
         onTap: (i) => setState(() => _index = i),
         items: const [
           BottomNavigationBarItem(icon: Icon(Icons.article), label: 'Новости'),
+          BottomNavigationBarItem(icon: Icon(Icons.event), label: 'События'),
+          BottomNavigationBarItem(icon: Icon(Icons.local_activity), label: 'Афиша'),
         ],
       ),
     );


### PR DESCRIPTION
## Summary
- add placeholder widgets for Events and Poster tabs in the home screen
- expand bottom navigation to include News, Events, and Poster entries

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9c9c16b848326b4d1de42ca668a4a