### PR TITLE
Reduce home app bar logo size

### DIFF
--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -29,7 +29,7 @@ class _HomeScreenState extends State<HomeScreen> {
         elevation: 0,
         title: Image.asset(
           'assets/images/logo_light_mobile.png',
-          height: 60,
+          height: 30,
           fit: BoxFit.contain,
         ),
       ),


### PR DESCRIPTION
## Summary
- reduce the app bar logo height on the home screen to make it more compact

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c9cadf68cc83269e30b1e6afe437f3