### PR TITLE
Ensure NewsPage receives non-null page count

### DIFF
--- a/lib/core/services/news_api_service.dart
+++ b/lib/core/services/news_api_service.dart
@@ -117,7 +117,14 @@ class NewsApiService {
       pages = (total / safePerPage).ceil();
     }
 
-    return NewsPage(items: items, page: pageNum, pages: pages, total: total);
+    final pagesCount = pages ?? (total / safePerPage).ceil();
+
+    return NewsPage(
+      items: items,
+      page: pageNum,
+      pages: pagesCount,
+      total: total,
+    );
   }
 
   String _resolveLang() {


### PR DESCRIPTION
## Summary
- ensure a non-null page count is calculated after the existing pagination fallback
- pass the computed count to the `NewsPage` constructor to satisfy the `int` requirement

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9d43e925c8326a858d13caed3cc0e