### PR TITLE
Clean news preview text

### DIFF
--- a/lib/core/utils/html_utils.dart
+++ b/lib/core/utils/html_utils.dart
@@ -1,0 +1,6 @@
+String htmlToPlainText(String source) {
+  return source
+      .replaceAll(RegExp(r'<[^>]*>'), ' ')
+      .replaceAll(RegExp(r'\s+'), ' ')
+      .trim();
+}

--- a/lib/features/news/news_article_view.dart
+++ b/lib/features/news/news_article_view.dart
@@ -4,6 +4,7 @@ import 'package:flutter_html/flutter_html.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../../core/utils/html_utils.dart';
 import '../../core/utils/image_brightness.dart';
 import '../../core/utils/time_ago.dart';
 import 'models/news_item.dart';
@@ -91,10 +92,7 @@ class _NewsArticleViewState extends State<NewsArticleView> {
         ? SystemUiOverlayStyle.dark
         : (dark ? SystemUiOverlayStyle.light : SystemUiOverlayStyle.dark);
 
-    final descPlain = item.contentPreview
-        .replaceAll(RegExp(r'<[^>]*>'), ' ')
-        .replaceAll(RegExp(r'\s+'), ' ')
-        .trim();
+    final descPlain = htmlToPlainText(item.contentPreview);
 
     final meta = [
       if (item.published != null) timeAgo(item.published),

--- a/lib/features/news/news_list.dart
+++ b/lib/features/news/news_list.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../../core/services/news_api_service.dart';
+import '../../core/utils/html_utils.dart';
 import '../../core/utils/time_ago.dart';
 import 'models/news_item.dart';
 import 'package:share_plus/share_plus.dart';
@@ -172,6 +173,7 @@ class NewsListItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final imageHeight = MediaQuery.of(context).size.width * 0.6;
+    final previewPlain = htmlToPlainText(item.contentPreview);
     return GestureDetector(
       onTap: onTap,
       child: Column(
@@ -219,17 +221,18 @@ class NewsListItem extends StatelessWidget {
                     fontFamily: 'Roboto',
                   ),
                 ),
-                Padding(
-                  padding: const EdgeInsets.only(top: 8),
-                  child: Text(
-                    item.contentPreview,
-                    style: const TextStyle(
-                      fontSize: 16,
-                      fontWeight: FontWeight.w300,
-                      fontFamily: 'Roboto',
+                if (previewPlain.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 8),
+                    child: Text(
+                      previewPlain,
+                      style: const TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w300,
+                        fontFamily: 'Roboto',
+                      ),
                     ),
                   ),
-                ),
                 Padding(
                   padding: const EdgeInsets.only(top: 12),
                   child: Row(


### PR DESCRIPTION
## Summary
- add an htmlToPlainText utility to strip tags and normalize whitespace
- reuse the helper when rendering article and list previews
- hide the news list preview block when the cleaned text is empty

## Testing
- flutter test *(fails: `flutter` command is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d65bfeec8326afede122a3141ac0