### PR TITLE
Adjust HTML margins in news article view

### DIFF
--- a/lib/features/news/news_article_view.dart
+++ b/lib/features/news/news_article_view.dart
@@ -258,6 +258,9 @@ class _NewsArticleViewState extends State<NewsArticleView> {
                       data: item.contentFull,
                       style: {
                         '*': Style(fontSize: FontSize(18 * _textScaleFactor)),
+                        'p': Style(margin: Margins.only(top: 0, bottom: 12)),
+                        'ul': Style(margin: Margins.only(top: 0, bottom: 12)),
+                        'ol': Style(margin: Margins.only(top: 0, bottom: 12)),
                       },
                     ),
                   ],


### PR DESCRIPTION
## Summary
- add explicit margin styling for paragraphs in news articles
- align ordered and unordered list spacing with paragraph spacing

## Testing
- flutter analyze *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9daa4abc88326b0c8d062e4576cdb