### PR TITLE
Add events feature with API integration

### DIFF
--- a/lib/core/services/events_api_service.dart
+++ b/lib/core/services/events_api_service.dart
@@ -1,0 +1,271 @@
+import 'dart:ui' as ui;
+
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+
+import '../../features/events/models/event_category.dart';
+import '../../features/events/models/event_item.dart';
+import '../../features/events/models/event_page.dart';
+
+class EventsApiService {
+  static final EventsApiService _instance = EventsApiService._internal();
+
+  factory EventsApiService() => _instance;
+
+  EventsApiService._internal() {
+    _dio = Dio(
+      BaseOptions(
+        baseUrl: 'https://gorodmore.ru/api/',
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept-Language': _resolveLang(),
+        },
+        connectTimeout: const Duration(seconds: 10),
+        receiveTimeout: const Duration(seconds: 10),
+      ),
+    );
+  }
+
+  late Dio _dio;
+
+  @visibleForTesting
+  Dio get dio => _dio;
+
+  /// Получить список лент событий (feeds)
+  Future<List<EventCategory>> fetchFeeds() async {
+    final res = await _dio.get('events/feeds');
+    final raw = res.data;
+    final payload = _unwrapResponse(raw);
+
+    final categories = <EventCategory>[];
+    final data = _extractList(payload) ?? _extractList(raw);
+    if (data != null) {
+      for (final item in data) {
+        if (item is Map<String, dynamic>) {
+          categories.add(EventCategory.fromJson(item));
+        }
+      }
+    } else if (payload is Map) {
+      for (final entry in payload.entries) {
+        if (entry.value is Map<String, dynamic>) {
+          categories
+              .add(EventCategory.fromJson(entry.value as Map<String, dynamic>));
+        }
+      }
+    }
+
+    return categories;
+  }
+
+  /// Получить страницу событий
+  Future<EventPage> fetchEvents({
+    int page = 1,
+    int perPage = 20,
+    String? feedId,
+  }) async {
+    final params = <String, dynamic>{'page': page, 'perPage': perPage};
+    if (feedId != null && feedId.isNotEmpty) {
+      params['feed_id'] = feedId;
+    }
+
+    final res = await _dio.get('events', queryParameters: params);
+    final raw = res.data;
+    final payload = _unwrapResponse(raw);
+
+    final rawItems = _extractList(payload) ?? _extractList(raw);
+    if (rawItems == null || rawItems.isEmpty) {
+      throw Exception('No event items found in response');
+    }
+
+    final items = <EventItem>[];
+    for (final item in rawItems) {
+      if (item is Map<String, dynamic>) {
+        items.add(EventItem.fromJson(item));
+      }
+    }
+
+    if (items.isEmpty) {
+      throw Exception('No event items could be parsed');
+    }
+
+    final pagination =
+        _extractPagination(payload) ?? _extractPagination(raw) ?? const {};
+
+    final pageNum =
+        _parseInt(pagination['page'] ?? pagination['current_page']) ?? page;
+
+    final perPageVal = _parseInt(
+          pagination['perPage'] ??
+              pagination['per_page'] ??
+              pagination['limit'],
+        ) ??
+        perPage;
+
+    final total = _parseInt(
+          pagination['total'] ??
+              pagination['total_items'] ??
+              pagination['totalItems'] ??
+              pagination['count'],
+        ) ??
+        items.length;
+
+    int? pages = _parseInt(
+      pagination['pages'] ??
+          pagination['last_page'] ??
+          pagination['total_pages'] ??
+          pagination['lastPage'],
+    );
+
+    final safePerPage = perPageVal > 0
+        ? perPageVal
+        : (items.isNotEmpty ? items.length : 1);
+    if (pages == null && safePerPage > 0) {
+      pages = (total / safePerPage).ceil();
+    }
+
+    final pagesCount = pages ?? (total / safePerPage).ceil();
+
+    return EventPage(
+      items: items,
+      page: pageNum,
+      pages: pagesCount,
+      total: total,
+    );
+  }
+
+  String _resolveLang() {
+    final code = ui.PlatformDispatcher.instance.locale.languageCode.toLowerCase();
+    return code == 'ru' ? 'ru' : 'en';
+  }
+
+  dynamic _unwrapResponse(dynamic raw) {
+    if (raw is Map) {
+      for (final key in const ['data', 'result', 'payload']) {
+        if (raw[key] != null) {
+          return raw[key];
+        }
+      }
+    }
+    return raw;
+  }
+
+  List<dynamic>? _extractList(dynamic data) {
+    if (data is List) {
+      return data;
+    }
+    if (data is Map) {
+      for (final key in const ['items', 'events', 'list', 'results', 'data']) {
+        if (data.containsKey(key)) {
+          final list = _extractList(data[key]);
+          if (list != null) {
+            return list;
+          }
+        }
+      }
+
+      final mapValues = <Map<String, dynamic>>[];
+      data.forEach((key, value) {
+        final keyStr = key.toString();
+        if ({'pagination', 'meta', '_meta', 'links', '_links'}.contains(keyStr)) {
+          return;
+        }
+        if (value is Map<String, dynamic>) {
+          mapValues.add(value);
+        }
+      });
+      if (mapValues.isNotEmpty) {
+        return mapValues;
+      }
+
+      for (final entry in data.entries) {
+        final keyStr = entry.key.toString();
+        if ({'pagination', 'meta', '_meta', 'links', '_links'}.contains(keyStr)) {
+          continue;
+        }
+        final list = _extractList(entry.value);
+        if (list != null) {
+          return list;
+        }
+      }
+    }
+    return null;
+  }
+
+  Map<String, dynamic>? _extractPagination(dynamic source) {
+    if (source is Map) {
+      for (final key in const ['pagination', 'meta']) {
+        final value = source[key];
+        if (value is Map) {
+          if (_looksLikePagination(value)) {
+            return value.map((k, v) => MapEntry(k.toString(), v));
+          }
+          final nested = _extractPagination(value);
+          if (nested != null) {
+            return nested;
+          }
+        }
+      }
+
+      for (final entry in source.entries) {
+        final value = entry.value;
+        if (value is Map) {
+          if (_looksLikePagination(value)) {
+            return value.map((k, v) => MapEntry(k.toString(), v));
+          }
+          final nested = _extractPagination(value);
+          if (nested != null) {
+            return nested;
+          }
+        }
+      }
+    }
+    return null;
+  }
+
+  bool _looksLikePagination(Map<dynamic, dynamic> map) {
+    const keys = {
+      'page',
+      'current_page',
+      'currentPage',
+      'per_page',
+      'perPage',
+      'limit',
+      'total',
+      'total_items',
+      'totalItems',
+      'count',
+      'pages',
+      'last_page',
+      'lastPage',
+      'total_pages',
+      'totalPages',
+    };
+    for (final key in map.keys) {
+      if (keys.contains(key.toString())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  int? _parseInt(dynamic value) {
+    if (value is num) {
+      return value.toInt();
+    }
+    if (value is String) {
+      final trimmed = value.trim();
+      if (trimmed.isEmpty) {
+        return null;
+      }
+      final parsed = int.tryParse(trimmed);
+      if (parsed != null) {
+        return parsed;
+      }
+      final asDouble = double.tryParse(trimmed);
+      if (asDouble != null) {
+        return asDouble.toInt();
+      }
+    }
+    return null;
+  }
+}

--- a/lib/features/events/events_detail_screen.dart
+++ b/lib/features/events/events_detail_screen.dart
@@ -1,0 +1,168 @@
+import 'package:flutter/material.dart';
+
+import '../../core/utils/html_utils.dart';
+import 'models/event_item.dart';
+import 'utils/event_date_formatter.dart';
+
+class EventDetailScreen extends StatelessWidget {
+  const EventDetailScreen({super.key, required this.item});
+
+  final EventItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    final description = htmlToPlainText(
+      item.description.isNotEmpty ? item.description : item.summary,
+    );
+    final date = formatEventDateRange(
+      item.startDate,
+      item.endDate,
+      includeWeekday: true,
+    );
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          item.title.isNotEmpty ? item.title : 'Событие',
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+      ),
+      body: ListView(
+        children: [
+          if (item.image.isNotEmpty)
+            Hero(
+              tag: 'event-${item.id}',
+              child: Image.network(
+                item.image,
+                width: double.infinity,
+                height: 260,
+                fit: BoxFit.cover,
+                errorBuilder: (_, __, ___) => Container(
+                  height: 260,
+                  color: Colors.grey.shade200,
+                  alignment: Alignment.center,
+                  child: const Icon(Icons.event, size: 48, color: Colors.grey),
+                ),
+              ),
+            )
+          else
+            Container(
+              height: 260,
+              color: Colors.grey.shade200,
+              alignment: Alignment.center,
+              child: const Icon(Icons.event, size: 64, color: Colors.grey),
+            ),
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  item.title,
+                  style: const TextStyle(
+                    fontSize: 24,
+                    fontWeight: FontWeight.w600,
+                    fontFamily: 'Roboto',
+                  ),
+                ),
+                const SizedBox(height: 12),
+                if (date.isNotEmpty)
+                  _InfoRow(
+                    icon: Icons.schedule,
+                    text: date,
+                  ),
+                if (item.venueName.isNotEmpty || item.venueAddress.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 12),
+                    child: _InfoRow(
+                      icon: Icons.place,
+                      text: [
+                        if (item.venueName.isNotEmpty) item.venueName,
+                        if (item.venueAddress.isNotEmpty) item.venueAddress,
+                      ].join(', '),
+                    ),
+                  ),
+                if (item.price.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 12),
+                    child: _InfoRow(
+                      icon: Icons.sell,
+                      text: item.price,
+                    ),
+                  ),
+                if (item.organizer.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 12),
+                    child: _InfoRow(
+                      icon: Icons.business_center,
+                      text: item.organizer,
+                    ),
+                  ),
+                if (item.phone.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 12),
+                    child: _InfoRow(
+                      icon: Icons.phone,
+                      text: item.phone,
+                    ),
+                  ),
+                if (item.url.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 12),
+                    child: _InfoRow(
+                      icon: Icons.link,
+                      text: item.url,
+                    ),
+                  ),
+                if (description.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 20),
+                    child: Text(
+                      description,
+                      style: const TextStyle(
+                        fontSize: 16,
+                        height: 1.4,
+                      ),
+                    ),
+                  ),
+                if (description.isEmpty)
+                  const Padding(
+                    padding: EdgeInsets.only(top: 20),
+                    child: Text('Описание недоступно'),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _InfoRow extends StatelessWidget {
+  const _InfoRow({required this.icon, required this.text});
+
+  final IconData icon;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Icon(icon, size: 20, color: Colors.grey.shade600),
+        const SizedBox(width: 8),
+        Expanded(
+          child: Text(
+            text,
+            style: const TextStyle(
+              fontSize: 16,
+              color: Colors.black87,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/events/events_list.dart
+++ b/lib/features/events/events_list.dart
@@ -1,0 +1,307 @@
+import 'package:flutter/material.dart';
+
+import '../../core/services/events_api_service.dart';
+import '../../core/utils/html_utils.dart';
+import 'events_detail_screen.dart';
+import 'models/event_item.dart';
+import 'widgets/event_list_item_skeleton.dart';
+import 'utils/event_date_formatter.dart';
+
+class EventsList extends StatefulWidget {
+  const EventsList({super.key, this.categoryId});
+
+  final String? categoryId;
+
+  @override
+  State<EventsList> createState() => _EventsListState();
+}
+
+class _EventsListState extends State<EventsList> {
+  final _api = EventsApiService();
+  final _scrollController = ScrollController();
+  final List<EventItem> _items = [];
+  bool _isLoading = false;
+  String? _error;
+  int _page = 1;
+  int _pages = 1;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadMore();
+    _scrollController.addListener(_onScroll);
+  }
+
+  void _onScroll() {
+    if (_scrollController.position.extentAfter < 200) {
+      _loadMore();
+    }
+  }
+
+  Future<void> _refresh() async {
+    setState(() {
+      _items.clear();
+      _page = 1;
+      _pages = 1;
+      _error = null;
+    });
+    await _loadMore();
+  }
+
+  Future<void> _loadMore() async {
+    if (_isLoading || _page > _pages) return;
+    setState(() {
+      _isLoading = true;
+      _error = null;
+    });
+    try {
+      final page = await _api.fetchEvents(
+        page: _page,
+        feedId: widget.categoryId,
+      );
+      setState(() {
+        _items.addAll(page.items);
+        _page = page.page + 1;
+        _pages = page.pages;
+      });
+    } catch (e) {
+      setState(() {
+        _error = 'Ошибка загрузки';
+      });
+    } finally {
+      if (mounted) {
+        setState(() => _isLoading = false);
+      } else {
+        _isLoading = false;
+      }
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant EventsList oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.categoryId != widget.categoryId) {
+      _refresh();
+    }
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_items.isEmpty) {
+      if (_isLoading) {
+        return ListView.separated(
+          itemCount: 5,
+          separatorBuilder: (_, __) => const Divider(height: 0),
+          itemBuilder: (_, __) => const EventListItemSkeleton(),
+        );
+      }
+      if (_error != null) {
+        return Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(_error!),
+              const SizedBox(height: 8),
+              ElevatedButton(
+                onPressed: _loadMore,
+                child: const Text('Повторить'),
+              ),
+            ],
+          ),
+        );
+      }
+      return const Center(child: Text('Нет данных'));
+    }
+
+    final showBottom = _isLoading || _error != null;
+
+    return RefreshIndicator(
+      onRefresh: _refresh,
+      child: ListView.separated(
+        controller: _scrollController,
+        itemCount: _items.length + (showBottom ? 1 : 0),
+        separatorBuilder: (context, index) {
+          if (index >= _items.length - 1) {
+            return const SizedBox.shrink();
+          }
+          return const Divider(height: 0);
+        },
+        itemBuilder: (context, index) {
+          if (index >= _items.length) {
+            if (_isLoading) {
+              return const EventListItemSkeleton();
+            } else {
+              return Padding(
+                padding: const EdgeInsets.symmetric(vertical: 16),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(_error ?? 'Ошибка'),
+                    const SizedBox(height: 8),
+                    ElevatedButton(
+                      onPressed: _loadMore,
+                      child: const Text('Повторить'),
+                    ),
+                  ],
+                ),
+              );
+            }
+          }
+          final item = _items[index];
+          return EventListItem(
+            item: item,
+            onTap: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => EventDetailScreen(item: item),
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}
+
+class EventListItem extends StatelessWidget {
+  const EventListItem({super.key, required this.item, this.onTap});
+
+  final EventItem item;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final imageHeight = MediaQuery.of(context).size.width * 0.56;
+    final summary = htmlToPlainText(item.summary.isNotEmpty
+        ? item.summary
+        : item.description);
+    final date = formatEventDateRange(item.startDate, item.endDate);
+
+    return GestureDetector(
+      onTap: onTap,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (item.image.isNotEmpty)
+            Hero(
+              tag: 'event-${item.id}',
+              child: Image.network(
+                item.image,
+                width: double.infinity,
+                height: imageHeight,
+                fit: BoxFit.cover,
+                errorBuilder: (_, __, ___) => Container(
+                  height: imageHeight,
+                  color: Colors.grey.shade200,
+                ),
+              ),
+            )
+          else
+            Container(
+              width: double.infinity,
+              height: imageHeight,
+              color: Colors.grey.shade200,
+              child: const Icon(Icons.event, size: 48, color: Colors.grey),
+            ),
+          Padding(
+            padding: const EdgeInsets.all(12),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (date.isNotEmpty)
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      const Icon(Icons.schedule, size: 18, color: Colors.grey),
+                      const SizedBox(width: 6),
+                      Expanded(
+                        child: Text(
+                          date,
+                          style: const TextStyle(
+                            fontSize: 14,
+                            fontWeight: FontWeight.w500,
+                            color: Colors.grey,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                const SizedBox(height: 6),
+                Text(
+                  item.title,
+                  style: const TextStyle(
+                    fontSize: 20,
+                    fontWeight: FontWeight.w500,
+                    fontFamily: 'Roboto',
+                  ),
+                ),
+                if (summary.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 8),
+                    child: Text(
+                      summary,
+                      style: const TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w300,
+                        fontFamily: 'Roboto',
+                      ),
+                    ),
+                  ),
+                if (item.venueName.isNotEmpty || item.venueAddress.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 12),
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        const Icon(Icons.place, size: 18, color: Colors.grey),
+                        const SizedBox(width: 6),
+                        Expanded(
+                          child: Text(
+                            [
+                              if (item.venueName.isNotEmpty) item.venueName,
+                              if (item.venueAddress.isNotEmpty) item.venueAddress,
+                            ].join(', '),
+                            style: const TextStyle(
+                              fontSize: 15,
+                              color: Colors.grey,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                if (item.price.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 8),
+                    child: Row(
+                      children: [
+                        const Icon(Icons.sell, size: 18, color: Colors.grey),
+                        const SizedBox(width: 6),
+                        Expanded(
+                          child: Text(
+                            item.price,
+                            style: const TextStyle(
+                              fontSize: 15,
+                              color: Colors.grey,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/lib/features/events/events_screen.dart
+++ b/lib/features/events/events_screen.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+
+import '../../core/services/events_api_service.dart';
+import 'events_list.dart';
+import 'models/event_category.dart';
+
+class EventsScreen extends StatefulWidget {
+  const EventsScreen({super.key});
+
+  @override
+  State<EventsScreen> createState() => _EventsScreenState();
+}
+
+class _EventsScreenState extends State<EventsScreen> {
+  final _api = EventsApiService();
+  List<EventCategory> _categories = [];
+  bool _isLoading = true;
+  String? _error;
+  int _selectedIndex = 0;
+  TabController? _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadCategories();
+  }
+
+  void _handleTabChanged() {
+    final controller = _tabController;
+    if (controller == null) return;
+    if (!controller.indexIsChanging && _selectedIndex != controller.index) {
+      setState(() => _selectedIndex = controller.index);
+    }
+  }
+
+  Future<void> _loadCategories() async {
+    setState(() {
+      _isLoading = true;
+      _error = null;
+    });
+    try {
+      final cats = await _api.fetchFeeds();
+      if (!mounted) return;
+      setState(() {
+        _categories = cats;
+        _selectedIndex = _selectedIndex.clamp(0, cats.length);
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _error = 'Ошибка загрузки');
+    } finally {
+      if (mounted) {
+        setState(() => _isLoading = false);
+      } else {
+        _isLoading = false;
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _tabController?.removeListener(_handleTabChanged);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_isLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (_categories.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(_error ?? 'Нет данных'),
+            const SizedBox(height: 8),
+            ElevatedButton(
+              onPressed: _loadCategories,
+              child: const Text('Повторить'),
+            ),
+          ],
+        ),
+      );
+    }
+
+    final initialIndex = _selectedIndex.clamp(0, _categories.length);
+
+    return DefaultTabController(
+      length: _categories.length + 1,
+      initialIndex: initialIndex,
+      child: Column(
+        children: [
+          Builder(
+            builder: (context) {
+              final controller = DefaultTabController.of(context);
+              if (_tabController != controller) {
+                _tabController?.removeListener(_handleTabChanged);
+                _tabController = controller;
+                _tabController?.addListener(_handleTabChanged);
+              }
+              if (controller != null && controller.index != initialIndex) {
+                controller.index = initialIndex;
+              }
+              return TabBar(
+                isScrollable: true,
+                tabAlignment: TabAlignment.start,
+                tabs: [
+                  const Tab(text: 'Все события'),
+                  for (final cat in _categories) Tab(text: cat.name),
+                ],
+                onTap: (index) {
+                  if (_selectedIndex != index) {
+                    setState(() => _selectedIndex = index);
+                  }
+                },
+              );
+            },
+          ),
+          Expanded(
+            child: TabBarView(
+              children: [
+                const EventsList(
+                  key: PageStorageKey('events-all'),
+                ),
+                for (final cat in _categories)
+                  EventsList(
+                    key: PageStorageKey('events-${cat.id}'),
+                    categoryId: cat.id,
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/events/models/event_category.dart
+++ b/lib/features/events/models/event_category.dart
@@ -1,0 +1,25 @@
+class EventCategory {
+  final String id;
+  final String name;
+  final String description;
+  final String image;
+
+  EventCategory({
+    required this.id,
+    required this.name,
+    required this.description,
+    required this.image,
+  });
+
+  factory EventCategory.fromJson(Map<String, dynamic> json) {
+    return EventCategory(
+      id: json['id']?.toString() ?? json['feed_id']?.toString() ?? '',
+      name: json['name']?.toString() ?? json['title']?.toString() ?? '',
+      description:
+          (json['description'] ?? json['about'] ?? json['summary'] ?? '')
+              .toString(),
+      image: (json['image'] ?? json['image_url'] ?? json['cover'] ?? '')
+          .toString(),
+    );
+  }
+}

--- a/lib/features/events/models/event_item.dart
+++ b/lib/features/events/models/event_item.dart
@@ -1,0 +1,192 @@
+class EventItem {
+  final String id;
+  final String feedId;
+  final String title;
+  final String summary;
+  final String description;
+  final String image;
+  final String url;
+  final String price;
+  final String organizer;
+  final String phone;
+  final DateTime? startDate;
+  final DateTime? endDate;
+  final String venueName;
+  final String venueAddress;
+
+  EventItem({
+    required this.id,
+    required this.feedId,
+    required this.title,
+    required this.summary,
+    required this.description,
+    required this.image,
+    required this.url,
+    required this.price,
+    required this.organizer,
+    required this.phone,
+    this.startDate,
+    this.endDate,
+    required this.venueName,
+    required this.venueAddress,
+  });
+
+  factory EventItem.fromJson(Map<String, dynamic> json) {
+    final schedule = json['schedule'];
+    DateTime? start;
+    DateTime? end;
+    if (schedule is Map<String, dynamic>) {
+      start = _parseDateTime(
+            schedule['start'] ??
+                schedule['start_time'] ??
+                schedule['from'] ??
+                schedule['date_start'] ??
+                schedule['begin'],
+          ) ??
+          _parseDateTime(schedule['date']);
+      end = _parseDateTime(
+        schedule['end'] ??
+            schedule['end_time'] ??
+            schedule['to'] ??
+            schedule['date_end'] ??
+            schedule['finish'],
+      );
+    }
+
+    start ??= _parseDateTime(
+      json['start'] ??
+          json['start_time'] ??
+          json['startDate'] ??
+          json['start_date'] ??
+          json['date_start'] ??
+          json['date'],
+    );
+    end ??= _parseDateTime(
+      json['end'] ??
+          json['end_time'] ??
+          json['endDate'] ??
+          json['end_date'] ??
+          json['date_end'],
+    );
+
+    final location = json['location'] ?? json['place'] ?? json['venue'];
+    String venueName = '';
+    String venueAddress = '';
+    if (location is Map) {
+      venueName = (location['name'] ?? location['title'] ?? location['venue'])
+          .toString();
+      venueAddress =
+          (location['address'] ?? location['full_address'] ?? location['street'])
+              .toString();
+    } else if (location != null) {
+      venueName = location.toString();
+    }
+
+    venueName = venueName.isNotEmpty
+        ? venueName
+        : (json['venue_name'] ?? json['club'] ?? json['organisation'])
+            ?.toString() ??
+            '';
+    venueAddress = venueAddress.isNotEmpty
+        ? venueAddress
+        : (json['venue_address'] ??
+                json['address'] ??
+                json['location_address'] ??
+                json['place_address'])
+            ?.toString() ??
+            '';
+
+    return EventItem(
+      id: json['id']?.toString() ?? json['event_id']?.toString() ?? '',
+      feedId: json['feed_id']?.toString() ?? json['category_id']?.toString() ?? '',
+      title: json['title']?.toString() ?? json['name']?.toString() ?? '',
+      summary: (json['summary'] ??
+              json['intro'] ??
+              json['preview'] ??
+              json['short_description'] ??
+              json['teaser'] ??
+              '')
+          .toString(),
+      description: (json['description'] ??
+              json['content'] ??
+              json['body'] ??
+              json['full_description'] ??
+              '')
+          .toString(),
+      image: (json['image'] ??
+              json['image_url'] ??
+              json['poster'] ??
+              json['cover'] ??
+              json['photo'] ??
+              '')
+          .toString(),
+      url: (json['url'] ?? json['link'] ?? json['website'] ?? '').toString(),
+      price:
+          (json['price'] ?? json['cost'] ?? json['fee'] ?? json['ticket_price'] ?? '')
+              .toString(),
+      organizer:
+          (json['organizer'] ?? json['author'] ?? json['owner'] ?? '').toString(),
+      phone: (json['phone'] ?? json['contact_phone'] ?? '').toString(),
+      startDate: start,
+      endDate: end,
+      venueName: venueName,
+      venueAddress: venueAddress,
+    );
+  }
+
+  static DateTime? _parseDateTime(dynamic value) {
+    if (value == null) return null;
+    if (value is DateTime) return value;
+    if (value is int) {
+      if (value == 0) return null;
+      final ms = value < 1000000000000 ? value * 1000 : value;
+      return DateTime.fromMillisecondsSinceEpoch(ms, isUtc: true).toLocal();
+    }
+    if (value is double) {
+      final ms = value < 1000000000000 ? (value * 1000).round() : value.round();
+      return DateTime.fromMillisecondsSinceEpoch(ms, isUtc: true).toLocal();
+    }
+    if (value is List && value.isNotEmpty) {
+      for (final entry in value) {
+        final parsed = _parseDateTime(entry);
+        if (parsed != null) {
+          return parsed;
+        }
+      }
+      return null;
+    }
+    if (value is Map) {
+      final datePart = value['date'] ?? value['day'] ?? value['start'] ?? value['value'];
+      final timePart =
+          value['time'] ?? value['clock'] ?? value['start_time'] ?? value['hours'];
+      final combined = [datePart, timePart].whereType<String>().join(' ');
+      if (combined.isNotEmpty) {
+        final parsed = DateTime.tryParse(combined);
+        if (parsed != null) {
+          return parsed.toLocal();
+        }
+      }
+      if (datePart != null) {
+        return _parseDateTime(datePart);
+      }
+      if (timePart != null) {
+        return _parseDateTime(timePart);
+      }
+      return null;
+    }
+    if (value is String) {
+      final trimmed = value.trim();
+      if (trimmed.isEmpty) return null;
+      final normalized = trimmed.replaceAll('T', ' ');
+      final parsed = DateTime.tryParse(normalized);
+      if (parsed != null) {
+        return parsed.toLocal();
+      }
+      final withT = DateTime.tryParse(trimmed);
+      if (withT != null) {
+        return withT.toLocal();
+      }
+    }
+    return null;
+  }
+}

--- a/lib/features/events/models/event_page.dart
+++ b/lib/features/events/models/event_page.dart
@@ -1,0 +1,15 @@
+import 'event_item.dart';
+
+class EventPage {
+  final List<EventItem> items;
+  final int page;
+  final int pages;
+  final int total;
+
+  EventPage({
+    required this.items,
+    required this.page,
+    required this.pages,
+    required this.total,
+  });
+}

--- a/lib/features/events/utils/event_date_formatter.dart
+++ b/lib/features/events/utils/event_date_formatter.dart
@@ -1,0 +1,36 @@
+import 'package:intl/intl.dart';
+
+String formatEventDateRange(
+  DateTime? start,
+  DateTime? end, {
+  bool includeWeekday = false,
+}) {
+  if (start == null && end == null) return '';
+  final datePattern = includeWeekday ? 'EEEE, d MMMM' : 'd MMMM';
+  final dateFormatter = DateFormat(datePattern, 'ru');
+  final timeFormatter = DateFormat('HH:mm');
+
+  if (start == null) {
+    return 'до ${dateFormatter.format(end!)}';
+  }
+
+  if (end == null) {
+    final date = dateFormatter.format(start);
+    final time = timeFormatter.format(start);
+    return '$date · $time';
+  }
+
+  final sameDay = start.year == end.year &&
+      start.month == end.month &&
+      start.day == end.day;
+  final startDate = dateFormatter.format(start);
+  final startTime = timeFormatter.format(start);
+  final endDate = dateFormatter.format(end);
+  final endTime = timeFormatter.format(end);
+
+  if (sameDay) {
+    return '$startDate · $startTime – $endTime';
+  }
+
+  return '$startDate $startTime – $endDate $endTime';
+}

--- a/lib/features/events/widgets/event_list_item_skeleton.dart
+++ b/lib/features/events/widgets/event_list_item_skeleton.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:shimmer/shimmer.dart';
+
+class EventListItemSkeleton extends StatelessWidget {
+  const EventListItemSkeleton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final imageHeight = MediaQuery.of(context).size.width * 0.56;
+    return Shimmer.fromColors(
+      baseColor: Colors.grey.shade300,
+      highlightColor: Colors.grey.shade100,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            width: double.infinity,
+            height: imageHeight,
+            color: Colors.grey,
+          ),
+          Padding(
+            padding: const EdgeInsets.all(12),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Container(
+                  width: 140,
+                  height: 12,
+                  color: Colors.grey,
+                ),
+                const SizedBox(height: 8),
+                Container(
+                  width: double.infinity,
+                  height: 18,
+                  color: Colors.grey,
+                ),
+                const SizedBox(height: 8),
+                Container(
+                  width: double.infinity,
+                  height: 14,
+                  color: Colors.grey,
+                ),
+                const SizedBox(height: 12),
+                Container(
+                  width: 200,
+                  height: 14,
+                  color: Colors.grey,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../events/events_screen.dart';
 import '../news/news_screen.dart';
 
 class HomeScreen extends StatefulWidget {
@@ -14,7 +15,7 @@ class _HomeScreenState extends State<HomeScreen> {
   static const _primary = Color(0xFF182857);
   static const List<Widget> _pages = [
     NewsScreen(),
-    Center(child: Text('События')),
+    EventsScreen(),
     Center(child: Text('Афиша')),
   ];
 


### PR DESCRIPTION
## Summary
- add an events API client mirroring the news service to load feeds and paginated events
- define event models and utilities to parse categories, items, pagination, and date ranges from the API
- build events screens, list, detail view, and skeleton loaders with infinite scroll/refresh and hook the screen into the home navigation

## Testing
- flutter test *(fails: `flutter` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc21314d388326add7016c5a25b449