### PR TITLE
Use category_id query parameter for news category filtering

### DIFF
--- a/lib/core/services/news_api_service.dart
+++ b/lib/core/services/news_api_service.dart
@@ -60,7 +60,7 @@ class NewsApiService {
   }) async {
     final params = <String, dynamic>{'page': page, 'perPage': perPage};
     if (categoryId?.isNotEmpty ?? false) {
-      params['feed_id'] = categoryId;
+      params['category_id'] = categoryId;
     }
 
     final res = await _dio.get('news', queryParameters: params);

--- a/test/core/services/news_api_service_test.dart
+++ b/test/core/services/news_api_service_test.dart
@@ -142,7 +142,7 @@ void main() {
     expect(feeds.map((c) => c.id).toList(), ['10', 'alpha', 'beta']);
   });
 
-  test('fetchNews sends feed id when provided', () async {
+  test('fetchNews sends category id when provided', () async {
     String? passedCategoryId;
     service.dio.interceptors.add(
       InterceptorsWrapper(
@@ -162,7 +162,8 @@ void main() {
           }
 
           if (options.path.endsWith('news')) {
-            passedCategoryId = options.queryParameters['feed_id']?.toString();
+            passedCategoryId =
+                options.queryParameters['category_id']?.toString();
             handler.resolve(
               Response(
                 requestOptions: options,


### PR DESCRIPTION
## Summary
- send the `category_id` query parameter when fetching news for a specific category
- update the news API service test to verify the new parameter name

## Testing
- flutter test *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68cc2a6bb6748326951eb07bcc6f9e61