### PR TITLE
Include content preview in event summaries

### DIFF
--- a/lib/features/events/models/event_item.dart
+++ b/lib/features/events/models/event_item.dart
@@ -101,9 +101,16 @@ class EventItem {
       feedId: json['feed_id']?.toString() ?? json['category_id']?.toString() ?? '',
       title: json['title']?.toString() ?? json['name']?.toString() ?? '',
       summary: (json['summary'] ??
+              json['content_preview'] ??
+              json['contentPreview'] ??
               json['intro'] ??
               json['preview'] ??
+              json['introtext'] ??
+              json['intro_text'] ??
               json['short_description'] ??
+              json['shortDescription'] ??
+              json['short_content'] ??
+              json['shortContent'] ??
               json['teaser'] ??
               '')
           .toString(),

--- a/test/features/events/event_item_test.dart
+++ b/test/features/events/event_item_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m_club/features/events/events_list.dart';
+import 'package:m_club/features/events/models/event_item.dart';
+
+void main() {
+  test('EventItem.fromJson uses content preview for summary', () {
+    final item = EventItem.fromJson({
+      'id': 42,
+      'feed_id': '100',
+      'title': 'Sample Event',
+      'content_preview': 'Short preview text',
+      'description': 'Longer description',
+    });
+
+    expect(item.summary, 'Short preview text');
+  });
+
+  testWidgets('EventListItem displays parsed summary text', (tester) async {
+    final item = EventItem.fromJson({
+      'id': 7,
+      'feed_id': '200',
+      'title': 'Preview Event',
+      'content_preview': '<p>Preview body</p>',
+      'description': '<p>Full description</p>',
+    });
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: EventListItem(item: item),
+        ),
+      ),
+    );
+
+    await tester.pump();
+
+    expect(find.text('Preview body'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- extend the EventItem summary fallbacks to recognize content preview keys
- cover parsing and rendering of the preview text with new unit and widget tests

## Testing
- flutter test (fails: Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cc31dd001483268c88df436d1b87e8