### PR TITLE
Expand event description fallbacks

### DIFF
--- a/lib/features/events/events_detail_screen.dart
+++ b/lib/features/events/events_detail_screen.dart
@@ -11,9 +11,9 @@ class EventDetailScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final description = htmlToPlainText(
-      item.description.isNotEmpty ? item.description : item.summary,
-    );
+    final rawDescription =
+        item.description.isNotEmpty ? item.description : item.summary;
+    final parsedDescription = htmlToPlainText(rawDescription);
     final date = formatEventDateRange(
       item.startDate,
       item.endDate,
@@ -115,18 +115,18 @@ class EventDetailScreen extends StatelessWidget {
                       text: item.url,
                     ),
                   ),
-                if (description.isNotEmpty)
+                if (parsedDescription.isNotEmpty)
                   Padding(
                     padding: const EdgeInsets.only(top: 20),
                     child: Text(
-                      description,
+                      parsedDescription,
                       style: const TextStyle(
                         fontSize: 16,
                         height: 1.4,
                       ),
                     ),
                   ),
-                if (description.isEmpty)
+                if (parsedDescription.isEmpty)
                   const Padding(
                     padding: EdgeInsets.only(top: 20),
                     child: Text('Описание недоступно'),

--- a/lib/features/events/models/event_item.dart
+++ b/lib/features/events/models/event_item.dart
@@ -117,6 +117,7 @@ class EventItem {
       description: (json['description'] ??
               json['content'] ??
               json['body'] ??
+              json['content_full'] ??
               json['full_description'] ??
               '')
           .toString(),


### PR DESCRIPTION
## Summary
- include the `content_full` field when deriving an event description so richer details are captured
- ensure the event details screen shows the parsed description text when available and only falls back to the placeholder when empty

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cc32d8e7e483269ed7a4162631eec5