### PR TITLE
Handle tickets data for event pricing

### DIFF
--- a/lib/features/events/events_detail_screen.dart
+++ b/lib/features/events/events_detail_screen.dart
@@ -14,6 +14,7 @@ class EventDetailScreen extends StatelessWidget {
     final description = htmlToPlainText(
       item.description.isNotEmpty ? item.description : item.summary,
     );
+    final ticketInfo = _formatTicketInfo(item.price);
     final date = formatEventDateRange(
       item.startDate,
       item.endDate,
@@ -83,12 +84,12 @@ class EventDetailScreen extends StatelessWidget {
                       ].join(', '),
                     ),
                   ),
-                if (item.price.isNotEmpty)
+                if (ticketInfo.isNotEmpty)
                   Padding(
                     padding: const EdgeInsets.only(top: 12),
                     child: _InfoRow(
                       icon: Icons.sell,
-                      text: item.price,
+                      text: ticketInfo,
                     ),
                   ),
                 if (item.organizer.isNotEmpty)
@@ -137,6 +138,35 @@ class EventDetailScreen extends StatelessWidget {
         ],
       ),
     );
+  }
+
+  String _formatTicketInfo(String price) {
+    final trimmed = price.trim();
+    if (trimmed.isEmpty) {
+      return '';
+    }
+
+    if (!trimmed.contains('<')) {
+      return trimmed;
+    }
+
+    final normalized = trimmed
+        .replaceAll(RegExp(r'<br\s*/?>', caseSensitive: false), '\n')
+        .replaceAll(RegExp(r'</p>', caseSensitive: false), '\n')
+        .replaceAll(RegExp(r'</div>', caseSensitive: false), '\n')
+        .replaceAll(RegExp(r'</li>', caseSensitive: false), '\n');
+
+    final segments = normalized
+        .split('\n')
+        .map((segment) => htmlToPlainText(segment).trim())
+        .where((segment) => segment.isNotEmpty)
+        .toList();
+
+    if (segments.isEmpty) {
+      return htmlToPlainText(normalized).trim();
+    }
+
+    return segments.join('\n');
   }
 }
 

--- a/lib/features/events/models/event_item.dart
+++ b/lib/features/events/models/event_item.dart
@@ -128,9 +128,7 @@ class EventItem {
               '')
           .toString(),
       url: (json['url'] ?? json['link'] ?? json['website'] ?? '').toString(),
-      price:
-          (json['price'] ?? json['cost'] ?? json['fee'] ?? json['ticket_price'] ?? '')
-              .toString(),
+      price: _extractTicketInfo(json),
       organizer:
           (json['organizer'] ?? json['author'] ?? json['owner'] ?? '').toString(),
       phone: (json['phone'] ?? json['contact_phone'] ?? '').toString(),
@@ -195,5 +193,94 @@ class EventItem {
       }
     }
     return null;
+  }
+
+  static String _extractTicketInfo(Map<String, dynamic> json) {
+    final candidates = [
+      json['price'],
+      json['cost'],
+      json['fee'],
+      json['ticket_price'],
+      json['tickets'],
+    ];
+
+    for (final candidate in candidates) {
+      final parsed = _stringifyTicketValue(candidate).trim();
+      if (parsed.isNotEmpty) {
+        return parsed;
+      }
+    }
+    return '';
+  }
+
+  static String _stringifyTicketValue(dynamic value) {
+    if (value == null) return '';
+    if (value is String) return value.trim();
+    if (value is num) return value.toString();
+    if (value is bool) return value ? 'true' : 'false';
+    if (value is Iterable) {
+      final items = value
+          .map(_stringifyTicketValue)
+          .where((element) => element.trim().isNotEmpty)
+          .toList();
+      if (items.isEmpty) return '';
+      return items.join('\n');
+    }
+    if (value is Map) {
+      final textKeys = ['text', 'description', 'info', 'details', 'summary'];
+      String text = '';
+      for (final key in textKeys) {
+        text = _stringifyTicketValue(value[key]);
+        if (text.isNotEmpty) break;
+      }
+
+      final name = _stringifyTicketValue(
+        value['name'] ??
+            value['title'] ??
+            value['label'] ??
+            value['type'] ??
+            value['category'],
+      );
+      final price = _stringifyTicketValue(
+        value['price'] ??
+            value['cost'] ??
+            value['fee'] ??
+            value['value'] ??
+            value['amount'],
+      );
+      final url = _stringifyTicketValue(
+        value['url'] ?? value['link'] ?? value['href'],
+      );
+
+      final parts = <String>[];
+      if (text.isNotEmpty) {
+        parts.add(text);
+      } else {
+        final namePriceParts = <String>[];
+        if (name.isNotEmpty) namePriceParts.add(name);
+        if (price.isNotEmpty) namePriceParts.add(price);
+        if (namePriceParts.isNotEmpty) {
+          parts.add(namePriceParts.join(' — '));
+        }
+      }
+
+      if (url.isNotEmpty) {
+        parts.add(url);
+      }
+
+      if (parts.isEmpty) {
+        final fallback = value.values
+            .map(_stringifyTicketValue)
+            .where((element) => element.trim().isNotEmpty)
+            .toList();
+        if (fallback.isNotEmpty) {
+          parts.addAll(fallback);
+        }
+      }
+
+      return parts.join('\n').trim();
+    }
+
+    return value.toString().trim();
   }
 }


### PR DESCRIPTION
## Summary
- parse ticket related fields when populating the event price fallback
- show the parsed ticket information in the event detail screen with light HTML cleanup

## Testing
- not run (Flutter SDK not available in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68cc34c8cb048326b46dd675cdb9f414