### PR TITLE
Add category name support for events list

### DIFF
--- a/lib/features/events/events_list.dart
+++ b/lib/features/events/events_list.dart
@@ -161,6 +161,7 @@ class _EventsListState extends State<EventsList> {
           final item = _items[index];
           return EventListItem(
             item: item,
+            eventCategoryName: item.categoryName,
             categoryName: widget.categoryNames[item.feedId],
             onTap: () {
               Navigator.of(context).push(
@@ -182,11 +183,13 @@ class EventListItem extends StatelessWidget {
     required this.item,
     this.onTap,
     this.categoryName,
+    this.eventCategoryName,
   });
 
   final EventItem item;
   final VoidCallback? onTap;
   final String? categoryName;
+  final String? eventCategoryName;
 
   @override
   Widget build(BuildContext context) {
@@ -219,9 +222,15 @@ class EventListItem extends StatelessWidget {
     ];
     final placeText =
         placeParts.isNotEmpty ? placeParts.join(', ') : 'Не указано';
-    final categoryText = (categoryName ?? '').trim().isNotEmpty
-        ? categoryName!.trim()
-        : 'Не указана';
+    final categoryCandidates = <String>[
+      if ((eventCategoryName ?? '').trim().isNotEmpty)
+        (eventCategoryName ?? '').trim(),
+      if (item.categoryName.trim().isNotEmpty) item.categoryName.trim(),
+      if ((categoryName ?? '').trim().isNotEmpty)
+        (categoryName ?? '').trim(),
+    ];
+    final categoryText =
+        categoryCandidates.isNotEmpty ? categoryCandidates.first : 'Не указана';
     final dateText = date.isNotEmpty ? date : 'Не указана';
 
     Widget buildPoster() {

--- a/lib/features/events/models/event_item.dart
+++ b/lib/features/events/models/event_item.dart
@@ -13,6 +13,7 @@ class EventItem {
   final DateTime? endDate;
   final String venueName;
   final String venueAddress;
+  final String categoryName;
 
   EventItem({
     required this.id,
@@ -29,6 +30,7 @@ class EventItem {
     this.endDate,
     required this.venueName,
     required this.venueAddress,
+    required this.categoryName,
   });
 
   factory EventItem.fromJson(Map<String, dynamic> json) {
@@ -137,6 +139,7 @@ class EventItem {
       endDate: end,
       venueName: venueName,
       venueAddress: venueAddress,
+      categoryName: _extractCategoryName(json),
     );
   }
 
@@ -283,5 +286,65 @@ class EventItem {
     }
 
     return value.toString().trim();
+  }
+
+  static String _extractCategoryName(Map<String, dynamic> json) {
+    String parseCategory(dynamic value) {
+      if (value == null) return '';
+      if (value is String) return value.trim();
+      if (value is num || value is bool) {
+        return value.toString();
+      }
+      if (value is Iterable) {
+        for (final element in value) {
+          final parsed = parseCategory(element);
+          if (parsed.isNotEmpty) {
+            return parsed;
+          }
+        }
+        return '';
+      }
+      if (value is Map) {
+        for (final key in const ['name', 'title', 'label', 'value', 'text']) {
+          final parsed = parseCategory(value[key]);
+          if (parsed.isNotEmpty) {
+            return parsed;
+          }
+        }
+        for (final entry in value.values) {
+          final parsed = parseCategory(entry);
+          if (parsed.isNotEmpty) {
+            return parsed;
+          }
+        }
+        return '';
+      }
+      return value.toString().trim();
+    }
+
+    final candidates = [
+      json['category'],
+      json['category_name'],
+      json['category_title'],
+      json['categoryName'],
+      json['categoryTitle'],
+      json['category_label'],
+      json['feed_name'],
+      json['feed_title'],
+      json['feedName'],
+      json['feedTitle'],
+      json['feed'],
+      json['section'],
+      json['type'],
+    ];
+
+    for (final candidate in candidates) {
+      final parsed = parseCategory(candidate);
+      if (parsed.isNotEmpty) {
+        return parsed;
+      }
+    }
+
+    return '';
   }
 }

--- a/test/features/events/event_item_test.dart
+++ b/test/features/events/event_item_test.dart
@@ -16,6 +16,26 @@ void main() {
     expect(item.summary, 'Short preview text');
   });
 
+  test('EventItem.fromJson extracts category name with fallbacks', () {
+    final directCategory = EventItem.fromJson({
+      'id': 1,
+      'feed_id': '500',
+      'title': 'Direct Category Event',
+      'category': {'title': 'Музыка'},
+    });
+
+    expect(directCategory.categoryName, 'Музыка');
+
+    final fallbackCategory = EventItem.fromJson({
+      'id': 2,
+      'feed_id': '501',
+      'title': 'Fallback Category Event',
+      'category_title': 'Театр',
+    });
+
+    expect(fallbackCategory.categoryName, 'Театр');
+  });
+
   testWidgets('EventListItem displays parsed summary text', (tester) async {
     final item = EventItem.fromJson({
       'id': 7,
@@ -36,5 +56,31 @@ void main() {
     await tester.pump();
 
     expect(find.text('Preview body'), findsOneWidget);
+  });
+
+  testWidgets('EventListItem prefers item category over fallback', (tester) async {
+    final item = EventItem.fromJson({
+      'id': 11,
+      'feed_id': '300',
+      'title': 'Category Event',
+      'category': 'Музыка',
+    });
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: EventListItem(
+            item: item,
+            eventCategoryName: item.categoryName,
+            categoryName: 'Фолбэк',
+          ),
+        ),
+      ),
+    );
+
+    await tester.pump();
+
+    expect(find.textContaining('Музыка'), findsOneWidget);
+    expect(find.textContaining('Фолбэк'), findsNothing);
   });
 }


### PR DESCRIPTION
## Summary
- add a categoryName field to EventItem and parse it from multiple possible JSON keys
- pass the parsed category through the events list and prioritise it over the local category map when rendering cards
- expand tests covering category extraction and UI fallback behaviour

## Testing
- flutter test *(fails: Flutter SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc40bc06ec8326835fe5228c00bf93