### PR TITLE
Handle time fallback for event dates

### DIFF
--- a/lib/features/events/events_detail_screen.dart
+++ b/lib/features/events/events_detail_screen.dart
@@ -22,6 +22,7 @@ class EventDetailScreen extends StatelessWidget {
       item.endDate,
       includeWeekday: true,
     );
+    final dateText = date.isNotEmpty ? date : item.fallbackDateText;
 
     return Scaffold(
       appBar: AppBar(
@@ -70,10 +71,10 @@ class EventDetailScreen extends StatelessWidget {
                   ),
                 ),
                 const SizedBox(height: 12),
-                if (date.isNotEmpty)
+                if (dateText.isNotEmpty)
                   _InfoRow(
                     icon: Icons.schedule,
-                    text: date,
+                    text: dateText,
                   ),
                 if (item.venueName.isNotEmpty || item.venueAddress.isNotEmpty)
                   Padding(

--- a/lib/features/events/events_list.dart
+++ b/lib/features/events/events_list.dart
@@ -194,6 +194,7 @@ class EventListItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final date = formatEventDateRange(item.startDate, item.endDate);
+    final fallbackDate = item.fallbackDateText;
     final theme = Theme.of(context);
     const posterWidth = 120.0;
     const posterAspectRatio = 3 / 4;
@@ -231,7 +232,9 @@ class EventListItem extends StatelessWidget {
     ];
     final categoryText =
         categoryCandidates.isNotEmpty ? categoryCandidates.first : 'Не указана';
-    final dateText = date.isNotEmpty ? date : 'Не указана';
+    final dateText = date.isNotEmpty
+        ? date
+        : (fallbackDate.isNotEmpty ? fallbackDate : 'Не указана');
 
     Widget buildPoster() {
       final borderRadius = BorderRadius.circular(12);

--- a/test/features/events/event_item_test.dart
+++ b/test/features/events/event_item_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:m_club/features/events/events_detail_screen.dart';
 import 'package:m_club/features/events/events_list.dart';
 import 'package:m_club/features/events/models/event_item.dart';
 
@@ -82,5 +83,48 @@ void main() {
 
     expect(find.textContaining('Музыка'), findsOneWidget);
     expect(find.textContaining('Фолбэк'), findsNothing);
+  });
+
+  testWidgets('EventListItem uses raw time when date parsing fails', (tester) async {
+    final item = EventItem.fromJson({
+      'id': 12,
+      'feed_id': '310',
+      'title': 'Time Only Event',
+      'time': '19:30',
+    });
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: EventListItem(item: item),
+        ),
+      ),
+    );
+
+    await tester.pump();
+
+    expect(find.text('19:30'), findsOneWidget);
+  });
+
+  testWidgets('EventDetailScreen shows raw time fallback when needed',
+      (tester) async {
+    final item = EventItem.fromJson({
+      'id': 13,
+      'feed_id': '320',
+      'title': 'Detail Time Event',
+      'time': '21:00',
+      'description': '',
+      'summary': '',
+    });
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: EventDetailScreen(item: item),
+      ),
+    );
+
+    await tester.pump();
+
+    expect(find.text('21:00'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- capture time-related strings when parsing events so they can be reused as schedule fallbacks
- show the fallback schedule string on the list and detail screens when parsed DateTime values are unavailable
- cover the fallback handling with widget tests

## Testing
- flutter test *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68cc42e00208832693942809ac1956ad