### PR TITLE
Revamp event detail layout and utilities

### DIFF
--- a/lib/core/utils/html_utils.dart
+++ b/lib/core/utils/html_utils.dart
@@ -1,6 +1,85 @@
 String htmlToPlainText(String source) {
-  return source
-      .replaceAll(RegExp(r'<[^>]*>'), ' ')
-      .replaceAll(RegExp(r'\s+'), ' ')
-      .trim();
+  if (source.trim().isEmpty) {
+    return '';
+  }
+
+  final blockTags = <String>{
+    'p',
+    'br',
+    'div',
+    'li',
+    'ul',
+    'ol',
+    'section',
+    'article',
+    'blockquote',
+    'h1',
+    'h2',
+    'h3',
+    'h4',
+    'h5',
+    'h6',
+    'table',
+    'thead',
+    'tbody',
+    'tfoot',
+    'tr',
+    'td',
+    'th',
+    'dl',
+    'dt',
+    'dd',
+  };
+
+  var text = source.replaceAll(RegExp(r'\r\n?'), '\n');
+
+  for (final tag in blockTags) {
+    final openingTagPattern = RegExp('<\\s*$tag[^>]*>', caseSensitive: false);
+    final closingTagPattern = RegExp('<\\s*/$tag[^>]*>', caseSensitive: false);
+    text = text.replaceAll(openingTagPattern, '\n');
+    if (tag != 'br') {
+      text = text.replaceAll(closingTagPattern, '\n');
+    }
+  }
+
+  text = text.replaceAll(RegExp(r'<[^>]+>'), ' ');
+
+  const entities = <String, String>{
+    '&nbsp;': ' ',
+    '&amp;': '&',
+    '&quot;': '"',
+    '&#39;': "'",
+    '&lt;': '<',
+    '&gt;': '>',
+  };
+  entities.forEach((entity, value) {
+    text = text.replaceAll(entity, value);
+  });
+
+  text = text.replaceAll(RegExp(r'[ \t\f\v]+'), ' ');
+  text = text.replaceAll(RegExp(r' *\n *'), '\n');
+  text = text.replaceAll(RegExp(r'\n{3,}'), '\n\n');
+
+  final lines = text.split('\n');
+  final buffer = <String>[];
+
+  for (final rawLine in lines) {
+    final line = rawLine.trim();
+    if (line.isEmpty) {
+      if (buffer.isNotEmpty && buffer.last.isNotEmpty) {
+        buffer.add('');
+      }
+    } else {
+      buffer.add(line);
+    }
+  }
+
+  while (buffer.isNotEmpty && buffer.first.isEmpty) {
+    buffer.removeAt(0);
+  }
+  while (buffer.isNotEmpty && buffer.last.isEmpty) {
+    buffer.removeLast();
+  }
+
+  return buffer.join('\n');
 }

--- a/lib/features/events/events_detail_screen.dart
+++ b/lib/features/events/events_detail_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:share_plus/share_plus.dart';
 
 import '../../core/utils/html_utils.dart';
 import 'models/event_item.dart';
@@ -11,6 +12,7 @@ class EventDetailScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
 
     final parsedDescription = htmlToPlainText(
       item.description.isNotEmpty ? item.description : item.summary,
@@ -24,6 +26,97 @@ class EventDetailScreen extends StatelessWidget {
     );
     final dateText = date.isNotEmpty ? date : item.fallbackDateText;
 
+    final colorScheme = theme.colorScheme;
+    const posterWidth = 120.0;
+    const posterAspectRatio = 3 / 4;
+    final posterHeight = posterWidth / posterAspectRatio;
+
+    final titleStyle = (theme.textTheme.titleMedium ?? const TextStyle())
+        .copyWith(
+      fontSize: 20,
+      fontWeight: FontWeight.w600,
+      color: colorScheme.onSurface,
+      height: 1.2,
+    );
+    final baseInfoStyle =
+        (theme.textTheme.bodyMedium ?? const TextStyle(fontSize: 14)).copyWith(
+      fontSize: 14,
+      color: colorScheme.onSurface.withOpacity(0.75),
+      height: 1.4,
+    );
+    final labelStyle = baseInfoStyle.copyWith(
+      fontWeight: FontWeight.w600,
+      color: colorScheme.onSurface,
+    );
+
+    Widget buildSummaryLine(String label, String value) {
+      return Text.rich(
+        TextSpan(
+          children: [
+            TextSpan(text: '$label: ', style: labelStyle),
+            TextSpan(text: value, style: baseInfoStyle),
+          ],
+        ),
+        softWrap: true,
+      );
+    }
+
+    Widget buildPoster() {
+      final borderRadius = BorderRadius.circular(12);
+      final placeholder = Container(
+        color: Colors.grey.shade200,
+        alignment: Alignment.center,
+        child: const Icon(Icons.event, size: 48, color: Colors.grey),
+      );
+
+      Widget posterChild;
+      if (item.image.isNotEmpty) {
+        posterChild = ClipRRect(
+          borderRadius: borderRadius,
+          child: Image.network(
+            item.image,
+            fit: BoxFit.cover,
+            errorBuilder: (_, __, ___) => placeholder,
+          ),
+        );
+      } else {
+        posterChild = ClipRRect(
+          borderRadius: borderRadius,
+          child: placeholder,
+        );
+      }
+
+      return GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: () => _openPoster(context),
+        child: Hero(
+          tag: 'event-${item.id}',
+          child: posterChild,
+        ),
+      );
+    }
+
+    void shareEvent() {
+      final locationParts = [
+        if (item.venueName.trim().isNotEmpty) item.venueName.trim(),
+        if (item.venueAddress.trim().isNotEmpty) item.venueAddress.trim(),
+      ];
+      final shareText = [
+        if (item.title.trim().isNotEmpty) item.title.trim(),
+        if (dateText.trim().isNotEmpty) dateText.trim(),
+        if (locationParts.isNotEmpty) locationParts.join(', '),
+        if (item.url.trim().isNotEmpty) item.url.trim(),
+      ].join('\n').trim();
+
+      if (shareText.isNotEmpty) {
+        Share.share(shareText);
+      }
+    }
+
+    final categoryText =
+        item.categoryName.trim().isNotEmpty ? item.categoryName.trim() : 'Не указана';
+    final dateSummary = dateText.isNotEmpty ? dateText : 'Не указана';
+
     return Scaffold(
       appBar: AppBar(
         title: Text(
@@ -31,46 +124,57 @@ class EventDetailScreen extends StatelessWidget {
           maxLines: 1,
           overflow: TextOverflow.ellipsis,
         ),
+        actions: [
+          IconButton(
+            onPressed: shareEvent,
+            tooltip: 'Поделиться',
+            icon: const Icon(Icons.share),
+          ),
+        ],
       ),
       body: ListView(
+        padding: const EdgeInsets.only(bottom: 24),
         children: [
-          if (item.image.isNotEmpty)
-            Hero(
-              tag: 'event-${item.id}',
-              child: Image.network(
-                item.image,
-                width: double.infinity,
-                height: 260,
-                fit: BoxFit.cover,
-                errorBuilder: (_, __, ___) => Container(
-                  height: 260,
-                  color: Colors.grey.shade200,
-                  alignment: Alignment.center,
-                  child: const Icon(Icons.event, size: 48, color: Colors.grey),
-                ),
-              ),
-            )
-          else
-            Container(
-              height: 260,
-              color: Colors.grey.shade200,
-              alignment: Alignment.center,
-              child: const Icon(Icons.event, size: 64, color: Colors.grey),
-            ),
           Padding(
-            padding: const EdgeInsets.all(16),
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                SizedBox(
+                  width: posterWidth,
+                  height: posterHeight,
+                  child: buildPoster(),
+                ),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        item.title,
+                        style: titleStyle,
+                      ),
+                      const SizedBox(height: 12),
+                      buildSummaryLine('Категория', categoryText),
+                      const SizedBox(height: 8),
+                      buildSummaryLine('Дата', dateSummary),
+                      if (ticketInfo.isNotEmpty) ...[
+                        const SizedBox(height: 8),
+                        buildSummaryLine('Билеты', ticketInfo),
+                      ],
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 16),
+          const Divider(height: 32, indent: 16, endIndent: 16),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(
-                  item.title,
-                  style: const TextStyle(
-                    fontSize: 24,
-                    fontWeight: FontWeight.w600,
-                    fontFamily: 'Roboto',
-                  ),
-                ),
-                const SizedBox(height: 12),
                 if (dateText.isNotEmpty)
                   _InfoRow(
                     icon: Icons.schedule,
@@ -124,13 +228,15 @@ class EventDetailScreen extends StatelessWidget {
                     padding: const EdgeInsets.only(top: 20),
                     child: Text(
                       parsedDescription,
+                      key: const Key('event-description'),
+                      softWrap: true,
                       style: const TextStyle(
                         fontSize: 16,
                         height: 1.4,
                       ),
                     ),
-                  ),
-                if (parsedDescription.isEmpty)
+                  )
+                else
                   const Padding(
                     padding: EdgeInsets.only(top: 20),
                     child: Text('Описание недоступно'),
@@ -139,6 +245,17 @@ class EventDetailScreen extends StatelessWidget {
             ),
           ),
         ],
+      ),
+    );
+  }
+
+  void _openPoster(BuildContext context) {
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => _EventPosterFullScreen(
+          imageUrl: item.image,
+          heroTag: 'event-${item.id}',
+        ),
       ),
     );
   }
@@ -196,6 +313,55 @@ class _InfoRow extends StatelessWidget {
           ),
         ),
       ],
+    );
+  }
+}
+
+class _EventPosterFullScreen extends StatelessWidget {
+  const _EventPosterFullScreen({
+    required this.imageUrl,
+    required this.heroTag,
+  });
+
+  final String imageUrl;
+  final String heroTag;
+
+  @override
+  Widget build(BuildContext context) {
+    final placeholder = Container(
+      width: 220,
+      height: 300,
+      color: Colors.grey.shade900,
+      alignment: Alignment.center,
+      child: const Icon(Icons.event, size: 96, color: Colors.white70),
+    );
+
+    Widget buildPoster() {
+      if (imageUrl.trim().isEmpty) {
+        return placeholder;
+      }
+
+      return Image.network(
+        imageUrl,
+        fit: BoxFit.contain,
+        errorBuilder: (_, __, ___) => placeholder,
+      );
+    }
+
+    return Scaffold(
+      backgroundColor: Colors.black,
+      appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        foregroundColor: Colors.white,
+        title: const Text('Постер'),
+      ),
+      body: Center(
+        child: Hero(
+          tag: heroTag,
+          child: buildPoster(),
+        ),
+      ),
     );
   }
 }

--- a/lib/features/events/models/event_item.dart
+++ b/lib/features/events/models/event_item.dart
@@ -399,21 +399,20 @@ class EventItem {
   }
 
   static String _extractTicketInfo(Map<String, dynamic> json) {
-    final candidates = [
-      json['price'],
-      json['cost'],
-      json['fee'],
-      json['ticket_price'],
-      json['tickets'],
-    ];
+    final tickets = json['tickets'];
+    final parsed = _stringifyTicketValue(tickets).trim();
 
-    for (final candidate in candidates) {
-      final parsed = _stringifyTicketValue(candidate).trim();
-      if (parsed.isNotEmpty) {
-        return parsed;
-      }
+    if (parsed.isEmpty) {
+      return '';
     }
-    return '';
+
+    final lowerParsed = parsed.toLowerCase();
+
+    if (parsed == '[]' || parsed == '{}' || lowerParsed == 'null') {
+      return '';
+    }
+
+    return parsed;
   }
 
   static String _stringifyTicketValue(dynamic value) {

--- a/test/core/utils/html_utils_test.dart
+++ b/test/core/utils/html_utils_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m_club/core/utils/html_utils.dart';
+
+void main() {
+  test('htmlToPlainText preserves paragraphs and line breaks', () {
+    const html =
+        '<p>Первый&nbsp;абзац</p><div>Второй<br>ряд</div><ul><li>Элемент 1</li><li>Элемент 2</li></ul>';
+
+    final result = htmlToPlainText(html);
+
+    expect(result, 'Первый абзац\n\nВторой\nряд\n\nЭлемент 1\nЭлемент 2');
+  });
+
+  test('htmlToPlainText trims redundant whitespace', () {
+    const html = '   <p>Первый</p> <p></p> <p>Второй</p>   ';
+
+    final result = htmlToPlainText(html);
+
+    expect(result, 'Первый\n\nВторой');
+  });
+}

--- a/test/features/events/event_item_test.dart
+++ b/test/features/events/event_item_test.dart
@@ -37,6 +37,33 @@ void main() {
     expect(fallbackCategory.categoryName, 'Театр');
   });
 
+  test('EventItem.fromJson builds ticket info from tickets field only', () {
+    final item = EventItem.fromJson({
+      'id': 21,
+      'feed_id': '510',
+      'title': 'Ticketed Event',
+      'price': 'Should be ignored',
+      'tickets': [
+        {'name': 'Взрослый', 'price': '500 ₽'},
+        {'name': 'Детский', 'price': '300 ₽'},
+      ],
+    });
+
+    expect(item.price, 'Взрослый — 500 ₽\nДетский — 300 ₽');
+  });
+
+  test('EventItem.fromJson keeps price empty when tickets lack info', () {
+    final item = EventItem.fromJson({
+      'id': 22,
+      'feed_id': '511',
+      'title': 'Free Event',
+      'price': '250 ₽',
+      'tickets': null,
+    });
+
+    expect(item.price, isEmpty);
+  });
+
   testWidgets('EventListItem displays parsed summary text', (tester) async {
     final item = EventItem.fromJson({
       'id': 7,
@@ -126,5 +153,68 @@ void main() {
     await tester.pump();
 
     expect(find.text('21:00'), findsOneWidget);
+  });
+
+  testWidgets('EventDetailScreen renders multiline description', (tester) async {
+    final item = EventItem.fromJson({
+      'id': 14,
+      'feed_id': '330',
+      'title': 'Description Event',
+      'description': '<p>Первый абзац</p><p>Второй абзац</p>',
+    });
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: EventDetailScreen(item: item),
+      ),
+    );
+
+    await tester.pump();
+
+    final description =
+        tester.widget<Text>(find.byKey(const Key('event-description')));
+    expect(description.data, 'Первый абзац\n\nВторой абзац');
+  });
+
+  testWidgets('EventDetailScreen hides ticket summary when absent', (tester) async {
+    final item = EventItem.fromJson({
+      'id': 15,
+      'feed_id': '331',
+      'title': 'No Tickets Event',
+      'description': '',
+    });
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: EventDetailScreen(item: item),
+      ),
+    );
+
+    await tester.pump();
+
+    expect(find.textContaining('Билеты'), findsNothing);
+  });
+
+  testWidgets('EventDetailScreen opens poster viewer on tap', (tester) async {
+    final item = EventItem.fromJson({
+      'id': 16,
+      'feed_id': '332',
+      'title': 'Poster Viewer Event',
+      'description': '',
+      'summary': '',
+    });
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: EventDetailScreen(item: item),
+      ),
+    );
+
+    await tester.pump();
+
+    await tester.tap(find.byHeroTag('event-${item.id}'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Постер'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- restructure the event detail screen to use a list-style header with a tappable hero poster, share action, and improved description rendering
- simplify ticket parsing to rely on the tickets payload and hide pricing when no meaningful data is present
- enhance HTML to plain text conversion and add tests covering HTML parsing, ticket extraction, and the new poster viewer behaviour

## Testing
- flutter test *(fails: flutter CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc4bb55d8083269b987a1c257b20c3