### PR TITLE
Add Afisha screen backed by calendar APIs

### DIFF
--- a/lib/features/afisha/afisha_screen.dart
+++ b/lib/features/afisha/afisha_screen.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+import '../../core/services/events_api_service.dart';
+import '../events/events_screen.dart';
+
+class AfishaScreen extends StatelessWidget {
+  const AfishaScreen({super.key});
+
+  static final EventsApiService _api =
+      EventsApiService(basePath: 'calendar');
+
+  @override
+  Widget build(BuildContext context) {
+    return EventsScreen(
+      apiService: _api,
+      storageKeyPrefix: 'afisha',
+    );
+  }
+}

--- a/lib/features/events/events_list.dart
+++ b/lib/features/events/events_list.dart
@@ -11,17 +11,19 @@ class EventsList extends StatefulWidget {
     super.key,
     this.categoryId,
     this.categoryNames = const {},
+    this.apiService,
   });
 
   final String? categoryId;
   final Map<String, String> categoryNames;
+  final EventsApiService? apiService;
 
   @override
   State<EventsList> createState() => _EventsListState();
 }
 
 class _EventsListState extends State<EventsList> {
-  final _api = EventsApiService();
+  late EventsApiService _api;
   final _scrollController = ScrollController();
   final List<EventItem> _items = [];
   bool _isLoading = false;
@@ -32,6 +34,7 @@ class _EventsListState extends State<EventsList> {
   @override
   void initState() {
     super.initState();
+    _api = widget.apiService ?? EventsApiService();
     _loadMore();
     _scrollController.addListener(_onScroll);
   }
@@ -84,6 +87,11 @@ class _EventsListState extends State<EventsList> {
   @override
   void didUpdateWidget(covariant EventsList oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (oldWidget.apiService != widget.apiService) {
+      _api = widget.apiService ?? EventsApiService();
+      _refresh();
+      return;
+    }
     if (oldWidget.categoryId != widget.categoryId) {
       _refresh();
     }

--- a/lib/features/events/events_screen.dart
+++ b/lib/features/events/events_screen.dart
@@ -5,14 +5,21 @@ import 'events_list.dart';
 import 'models/event_category.dart';
 
 class EventsScreen extends StatefulWidget {
-  const EventsScreen({super.key});
+  const EventsScreen({
+    super.key,
+    this.apiService,
+    this.storageKeyPrefix = 'events',
+  });
+
+  final EventsApiService? apiService;
+  final String storageKeyPrefix;
 
   @override
   State<EventsScreen> createState() => _EventsScreenState();
 }
 
 class _EventsScreenState extends State<EventsScreen> {
-  final _api = EventsApiService();
+  late EventsApiService _api;
   List<EventCategory> _categories = [];
   bool _isLoading = true;
   String? _error;
@@ -22,7 +29,17 @@ class _EventsScreenState extends State<EventsScreen> {
   @override
   void initState() {
     super.initState();
+    _api = widget.apiService ?? EventsApiService();
     _loadCategories();
+  }
+
+  @override
+  void didUpdateWidget(covariant EventsScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.apiService != widget.apiService) {
+      _api = widget.apiService ?? EventsApiService();
+      _loadCategories();
+    }
   }
 
   void _handleTabChanged() {
@@ -89,6 +106,7 @@ class _EventsScreenState extends State<EventsScreen> {
     final categoryNames = {
       for (final cat in _categories) cat.id: cat.name,
     };
+    final prefix = widget.storageKeyPrefix;
 
     return DefaultTabController(
       length: _categories.length + 1,
@@ -125,14 +143,16 @@ class _EventsScreenState extends State<EventsScreen> {
             child: TabBarView(
               children: [
                 EventsList(
-                  key: const PageStorageKey('events-all'),
+                  key: PageStorageKey('$prefix-all'),
                   categoryNames: categoryNames,
+                  apiService: _api,
                 ),
                 for (final cat in _categories)
                   EventsList(
-                    key: PageStorageKey('events-${cat.id}'),
+                    key: PageStorageKey('$prefix-${cat.id}'),
                     categoryId: cat.id,
                     categoryNames: categoryNames,
+                    apiService: _api,
                   ),
               ],
             ),

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../afisha/afisha_screen.dart';
 import '../events/events_screen.dart';
 import '../news/news_screen.dart';
 
@@ -16,7 +17,7 @@ class _HomeScreenState extends State<HomeScreen> {
   static const List<Widget> _pages = [
     NewsScreen(),
     EventsScreen(),
-    Center(child: Text('Афиша')),
+    AfishaScreen(),
   ];
 
   @override

--- a/test/core/services/events_api_service_test.dart
+++ b/test/core/services/events_api_service_test.dart
@@ -63,4 +63,51 @@ void main() {
     await service.fetchEvents(categoryId: '777');
     expect(passedCategoryId, '777');
   });
+
+  test('fetchEvents uses custom base path', () async {
+    final calendarService = EventsApiService(basePath: 'calendar');
+    String? requestedPath;
+
+    calendarService.dio.interceptors.add(
+      InterceptorsWrapper(
+        onRequest: (options, handler) {
+          requestedPath = options.path;
+          handler.resolve(
+            Response(
+              requestOptions: options,
+              data: {
+                'data': {
+                  'items': [
+                    {
+                      'id': 1,
+                      'feed_id': '777',
+                      'title': 'Event',
+                      'summary': 'Summary',
+                      'description': 'Description',
+                      'image': 'image.png',
+                      'url': 'https://example.com',
+                      'price': 'Free',
+                      'organizer': 'Org',
+                      'phone': '1234567890',
+                      'venue_name': 'Venue',
+                      'venue_address': 'Address',
+                    },
+                  ],
+                  'pagination': {
+                    'page': 1,
+                    'perPage': 10,
+                    'total': 1,
+                  },
+                },
+              },
+            ),
+          );
+        },
+      ),
+    );
+
+    await calendarService.fetchEvents();
+    expect(requestedPath, 'calendar');
+    calendarService.dio.interceptors.clear();
+  });
 }


### PR DESCRIPTION
## Summary
- allow EventsApiService to target different API base paths so it can call both /events and /calendar
- reuse the events UI to show an Afisha tab that pulls data from the calendar endpoints
- cover the new calendar path handling with a service test and wire the tab into the home screen navigation

## Testing
- flutter test *(fails: `bash: command not found: flutter`)*

------
https://chatgpt.com/codex/tasks/task_e_68cc57d950a88326866a260f245e5363