### PR TITLE
Add cinema section with schedule

### DIFF
--- a/lib/core/services/cinema_api_service.dart
+++ b/lib/core/services/cinema_api_service.dart
@@ -1,0 +1,99 @@
+import 'dart:ui' as ui;
+
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+
+import '../../features/cinema/models/cinema_film.dart';
+
+class CinemaApiService {
+  CinemaApiService() {
+    _dio = Dio(
+      BaseOptions(
+        baseUrl: 'https://gorodmore.ru/api/',
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept-Language': _resolveLang(),
+        },
+        connectTimeout: const Duration(seconds: 10),
+        receiveTimeout: const Duration(seconds: 10),
+      ),
+    );
+  }
+
+  late final Dio _dio;
+
+  @visibleForTesting
+  Dio get dio => _dio;
+
+  Future<List<CinemaFilm>> fetchFilms() async {
+    final res = await _dio.get('cinema');
+    final raw = res.data;
+    final payload = _unwrapResponse(raw);
+
+    final data = _extractList(payload) ?? _extractList(raw);
+    if (data == null) {
+      return const [];
+    }
+
+    final films = <CinemaFilm>[];
+    for (final item in data) {
+      if (item is Map<String, dynamic>) {
+        films.add(CinemaFilm.fromJson(item));
+      } else if (item is Map) {
+        films.add(
+          CinemaFilm.fromJson(
+            item.map((key, value) => MapEntry(key.toString(), value)),
+          ),
+        );
+      }
+    }
+
+    return films;
+  }
+
+  String _resolveLang() {
+    final code = ui.PlatformDispatcher.instance.locale.languageCode.toLowerCase();
+    return code == 'ru' ? 'ru' : 'en';
+  }
+
+  dynamic _unwrapResponse(dynamic raw) {
+    if (raw is Map) {
+      for (final key in const ['data', 'result', 'payload']) {
+        if (raw[key] != null) {
+          return raw[key];
+        }
+      }
+    }
+    return raw;
+  }
+
+  List<dynamic>? _extractList(dynamic data) {
+    if (data is List) {
+      return data;
+    }
+    if (data is Map) {
+      for (final key in const ['items', 'cinema', 'films', 'list', 'results']) {
+        if (data.containsKey(key)) {
+          final list = _extractList(data[key]);
+          if (list != null) {
+            return list;
+          }
+        }
+      }
+      final mapValues = <Map<String, dynamic>>[];
+      data.forEach((key, value) {
+        final keyStr = key.toString();
+        if ({'pagination', 'meta', '_meta', 'links', '_links'}.contains(keyStr)) {
+          return;
+        }
+        if (value is Map<String, dynamic>) {
+          mapValues.add(value);
+        }
+      });
+      if (mapValues.isNotEmpty) {
+        return mapValues;
+      }
+    }
+    return null;
+  }
+}

--- a/lib/features/cinema/cinema_screen.dart
+++ b/lib/features/cinema/cinema_screen.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+
+import '../../core/services/cinema_api_service.dart';
+import 'models/cinema_film.dart';
+import 'widgets/cinema_film_card.dart';
+
+class CinemaScreen extends StatefulWidget {
+  const CinemaScreen({super.key, this.apiService});
+
+  final CinemaApiService? apiService;
+
+  @override
+  State<CinemaScreen> createState() => _CinemaScreenState();
+}
+
+class _CinemaScreenState extends State<CinemaScreen> {
+  late CinemaApiService _api;
+  List<CinemaFilm> _films = [];
+  bool _isLoading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _api = widget.apiService ?? CinemaApiService();
+    _loadFilms();
+  }
+
+  @override
+  void didUpdateWidget(covariant CinemaScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.apiService != widget.apiService) {
+      _api = widget.apiService ?? CinemaApiService();
+      _loadFilms();
+    }
+  }
+
+  Future<void> _loadFilms({bool refresh = false}) async {
+    if (!refresh) {
+      setState(() {
+        _isLoading = true;
+        _error = null;
+      });
+    } else {
+      setState(() {
+        _error = null;
+      });
+    }
+
+    try {
+      final films = await _api.fetchFilms();
+      if (!mounted) return;
+      setState(() {
+        _films = films;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _error = 'Ошибка загрузки';
+      });
+    } finally {
+      if (!mounted) return;
+      setState(() {
+        _isLoading = false;
+      });
+    }
+  }
+
+  Future<void> _handleRefresh() => _loadFilms(refresh: true);
+
+  @override
+  Widget build(BuildContext context) {
+    if (_isLoading && _films.isEmpty) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (_error != null && _films.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(_error!),
+            const SizedBox(height: 12),
+            ElevatedButton(
+              onPressed: _loadFilms,
+              child: const Text('Повторить'),
+            ),
+          ],
+        ),
+      );
+    }
+
+    if (_films.isEmpty) {
+      return RefreshIndicator(
+        onRefresh: _handleRefresh,
+        child: ListView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          children: const [
+            SizedBox(height: 80),
+            Center(child: Text('Нет данных')),
+          ],
+        ),
+      );
+    }
+
+    return RefreshIndicator(
+      onRefresh: _handleRefresh,
+      child: ListView.separated(
+        padding: const EdgeInsets.fromLTRB(0, 16, 0, 24),
+        physics: const AlwaysScrollableScrollPhysics(),
+        itemCount: _films.length,
+        itemBuilder: (context, index) {
+          final film = _films[index];
+          return CinemaFilmCard(film: film);
+        },
+        separatorBuilder: (_, __) => const SizedBox(height: 16),
+      ),
+    );
+  }
+}

--- a/lib/features/cinema/models/cinema_film.dart
+++ b/lib/features/cinema/models/cinema_film.dart
@@ -1,0 +1,107 @@
+import 'cinema_showtime.dart';
+
+class CinemaFilm {
+  CinemaFilm({
+    required this.filmId,
+    required this.name,
+    required this.imageUrl,
+    required this.genre,
+    required this.duration,
+    required this.rating,
+    required this.trailerUrl,
+    required this.uuid,
+    this.time,
+    this.description,
+    this.year,
+    this.poster,
+    this.ratingVotes,
+    this.replyCount,
+    List<CinemaShowtime>? showtimes,
+  }) : showtimes = List.unmodifiable(showtimes ?? const []);
+
+  final String filmId;
+  final String name;
+  final String imageUrl;
+  final String genre;
+  final String duration;
+  final String rating;
+  final String trailerUrl;
+  final String uuid;
+  final String? time;
+  final String? description;
+  final String? year;
+  final String? poster;
+  final int? ratingVotes;
+  final int? replyCount;
+  final List<CinemaShowtime> showtimes;
+
+  bool get hasPoster => imageUrl.isNotEmpty;
+  bool get hasTrailer => trailerUrl.isNotEmpty;
+
+  factory CinemaFilm.fromJson(Map<String, dynamic> json) {
+    final filmdata = json['filmdata'];
+
+    return CinemaFilm(
+      filmId: _stringValue(json['film_id']),
+      name: _stringValue(json['name']),
+      imageUrl: _stringValue(json['img']),
+      genre: _stringValue(json['genre']),
+      duration: _stringValue(json['duration']),
+      rating: _stringValue(json['rating']),
+      trailerUrl: _stringValue(json['lvideo']),
+      uuid: _stringValue(json['uuid']),
+      time: _nullableString(json['time']),
+      ratingVotes: _parseInt(json['ratingVotes']),
+      replyCount: _parseInt(json['replys']),
+      description: filmdata is Map ? _nullableString(filmdata['description']) : null,
+      year: filmdata is Map ? _nullableString(filmdata['year']) : null,
+      poster: filmdata is Map ? _nullableString(filmdata['poster']) : null,
+      showtimes: _parseShowtimes(json['showtimes']),
+    );
+  }
+
+  static List<CinemaShowtime> _parseShowtimes(dynamic value) {
+    if (value is List) {
+      return value
+          .whereType<Map>()
+          .map((raw) => raw.map((key, value) => MapEntry(key.toString(), value)))
+          .map(CinemaShowtime.fromJson)
+          .toList();
+    }
+    if (value is Map) {
+      final showtimes = <CinemaShowtime>[];
+      value.forEach((_, raw) {
+        if (raw is Map) {
+          showtimes.add(
+            CinemaShowtime.fromJson(
+              raw.map((key, value) => MapEntry(key.toString(), value)),
+            ),
+          );
+        }
+      });
+      return showtimes;
+    }
+    return const [];
+  }
+
+  static int? _parseInt(dynamic value) {
+    if (value == null) return null;
+    if (value is int) return value;
+    if (value is String) {
+      return int.tryParse(value);
+    }
+    return int.tryParse(value.toString());
+  }
+
+  static String _stringValue(dynamic value) {
+    if (value == null) return '';
+    if (value is String) return value;
+    return value.toString();
+  }
+
+  static String? _nullableString(dynamic value) {
+    if (value == null) return null;
+    final stringValue = _stringValue(value).trim();
+    return stringValue.isEmpty ? null : stringValue;
+  }
+}

--- a/lib/features/cinema/models/cinema_showtime.dart
+++ b/lib/features/cinema/models/cinema_showtime.dart
@@ -1,0 +1,39 @@
+class CinemaShowtime {
+  const CinemaShowtime({
+    required this.time,
+    required this.cinemaId,
+    required this.room,
+    required this.format,
+    required this.when,
+    required this.endTime,
+    required this.buyUrl,
+  });
+
+  final String time;
+  final String cinemaId;
+  final String room;
+  final String format;
+  final String when;
+  final String endTime;
+  final String buyUrl;
+
+  bool get hasBuyUrl => buyUrl.isNotEmpty;
+
+  factory CinemaShowtime.fromJson(Map<String, dynamic> json) {
+    return CinemaShowtime(
+      time: _stringValue(json['time']),
+      cinemaId: _stringValue(json['cinema_id']),
+      room: _stringValue(json['room']),
+      format: _stringValue(json['format']),
+      when: _stringValue(json['when']),
+      endTime: _stringValue(json['endTime']),
+      buyUrl: _stringValue(json['buyUrl']),
+    );
+  }
+
+  static String _stringValue(dynamic value) {
+    if (value == null) return '';
+    if (value is String) return value;
+    return value.toString();
+  }
+}

--- a/lib/features/cinema/widgets/cinema_film_card.dart
+++ b/lib/features/cinema/widgets/cinema_film_card.dart
@@ -1,0 +1,350 @@
+import 'dart:collection';
+
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../../core/utils/html_utils.dart';
+import '../models/cinema_film.dart';
+import '../models/cinema_showtime.dart';
+
+class CinemaFilmCard extends StatelessWidget {
+  const CinemaFilmCard({super.key, required this.film});
+
+  final CinemaFilm film;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final textTheme = theme.textTheme;
+
+    final infoChips = _buildInfoChips(colorScheme, textTheme);
+    final groups = _groupShowtimes(film.showtimes);
+    final description = film.description?.trim();
+
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 16),
+      clipBehavior: Clip.antiAlias,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      elevation: 2,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _Poster(imageUrl: film.imageUrl),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(20, 20, 20, 8),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  film.name.isNotEmpty ? film.name : 'Без названия',
+                  style: (textTheme.headlineSmall ?? const TextStyle()).copyWith(
+                    fontSize: 22,
+                    fontWeight: FontWeight.w700,
+                    color: colorScheme.onSurface,
+                  ),
+                ),
+                if (infoChips.isNotEmpty) ...[
+                  const SizedBox(height: 12),
+                  Wrap(
+                    spacing: 8,
+                    runSpacing: 8,
+                    children: infoChips,
+                  ),
+                ],
+                if (description != null && description.isNotEmpty) ...[
+                  const SizedBox(height: 16),
+                  Text(
+                    htmlToPlainText(description),
+                    style: (textTheme.bodyMedium ?? const TextStyle())
+                        .copyWith(height: 1.4),
+                  ),
+                ],
+              ],
+            ),
+          ),
+          if (groups.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 8, 20, 20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  for (final entry in groups.entries) ...[
+                    if (entry != groups.entries.first) const SizedBox(height: 16),
+                    Text(
+                      entry.key,
+                      style: (textTheme.titleMedium ?? const TextStyle()).copyWith(
+                        fontWeight: FontWeight.w600,
+                        color: colorScheme.primary,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    for (final showtime in entry.value)
+                      _ShowtimeTile(
+                        showtime: showtime,
+                        onBuyPressed: showtime.hasBuyUrl
+                            ? () => _openBuyUrl(context, showtime.buyUrl)
+                            : null,
+                      ),
+                  ],
+                ],
+              ),
+            )
+          else
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 0, 20, 20),
+              child: Text(
+                'Нет ближайших сеансов',
+                style: (textTheme.bodyMedium ?? const TextStyle()).copyWith(
+                  color: colorScheme.onSurface.withOpacity(0.7),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  List<Widget> _buildInfoChips(ColorScheme colorScheme, TextTheme textTheme) {
+    final chips = <Widget>[];
+
+    if (film.genre.isNotEmpty) {
+      chips.add(_InfoChip(
+        icon: Icons.local_movies_outlined,
+        label: film.genre,
+        colorScheme: colorScheme,
+        textTheme: textTheme,
+      ));
+    }
+
+    final durationText = _durationText(film.duration);
+    if (durationText != null) {
+      chips.add(_InfoChip(
+        icon: Icons.schedule_outlined,
+        label: durationText,
+        colorScheme: colorScheme,
+        textTheme: textTheme,
+      ));
+    }
+
+    final ratingText = _ratingText(film.rating, film.ratingVotes);
+    if (ratingText != null) {
+      chips.add(_InfoChip(
+        icon: Icons.star_rate_rounded,
+        label: ratingText,
+        colorScheme: colorScheme,
+        textTheme: textTheme,
+      ));
+    }
+
+    if (film.year != null && film.year!.isNotEmpty) {
+      chips.add(_InfoChip(
+        icon: Icons.event,
+        label: 'Год: ${film.year}',
+        colorScheme: colorScheme,
+        textTheme: textTheme,
+      ));
+    }
+
+    return chips;
+  }
+
+  LinkedHashMap<String, List<CinemaShowtime>> _groupShowtimes(
+    List<CinemaShowtime> showtimes,
+  ) {
+    final groups = LinkedHashMap<String, List<CinemaShowtime>>();
+    for (final showtime in showtimes) {
+      final key = showtime.when.isNotEmpty ? showtime.when : 'Расписание';
+      groups.putIfAbsent(key, () => []).add(showtime);
+    }
+    return groups;
+  }
+
+  String? _durationText(String raw) {
+    final trimmed = raw.trim();
+    if (trimmed.isEmpty) return null;
+    final parsed = int.tryParse(trimmed);
+    if (parsed != null && parsed > 0) {
+      return '$parsed мин';
+    }
+    return trimmed;
+  }
+
+  String? _ratingText(String rating, int? votes) {
+    final value = rating.trim();
+    if (value.isEmpty || value == '0') return null;
+    if (votes != null && votes > 0) {
+      return '$value ★ (${votes.toString()} голосов)';
+    }
+    return '$value ★';
+  }
+
+  Future<void> _openBuyUrl(BuildContext context, String url) async {
+    final uri = Uri.tryParse(url);
+    if (uri == null) {
+      _showLaunchError(context);
+      return;
+    }
+    try {
+      final opened = await launchUrl(uri, mode: LaunchMode.externalApplication);
+      if (!opened) {
+        _showLaunchError(context);
+      }
+    } catch (_) {
+      _showLaunchError(context);
+    }
+  }
+
+  void _showLaunchError(BuildContext context) {
+    if (!context.mounted) return;
+    final messenger = ScaffoldMessenger.maybeOf(context);
+    messenger?.showSnackBar(
+      const SnackBar(content: Text('Не удалось открыть ссылку')),
+    );
+  }
+}
+
+class _Poster extends StatelessWidget {
+  const _Poster({required this.imageUrl});
+
+  final String imageUrl;
+
+  @override
+  Widget build(BuildContext context) {
+    final placeholder = Container(
+      color: Colors.grey.shade200,
+      alignment: Alignment.center,
+      child: const Icon(Icons.local_movies, size: 48, color: Colors.grey),
+    );
+
+    if (imageUrl.isEmpty) {
+      return AspectRatio(aspectRatio: 3 / 4, child: placeholder);
+    }
+
+    return AspectRatio(
+      aspectRatio: 3 / 4,
+      child: Image.network(
+        imageUrl,
+        fit: BoxFit.cover,
+        errorBuilder: (_, __, ___) => placeholder,
+      ),
+    );
+  }
+}
+
+class _InfoChip extends StatelessWidget {
+  const _InfoChip({
+    required this.icon,
+    required this.label,
+    required this.colorScheme,
+    required this.textTheme,
+  });
+
+  final IconData icon;
+  final String label;
+  final ColorScheme colorScheme;
+  final TextTheme textTheme;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      decoration: BoxDecoration(
+        color: colorScheme.primary.withOpacity(0.08),
+        borderRadius: BorderRadius.circular(24),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 16, color: colorScheme.primary),
+          const SizedBox(width: 6),
+          Text(
+            label,
+            style: (textTheme.bodyMedium ?? const TextStyle()).copyWith(
+              fontWeight: FontWeight.w600,
+              color: colorScheme.primary,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ShowtimeTile extends StatelessWidget {
+  const _ShowtimeTile({required this.showtime, this.onBuyPressed});
+
+  final CinemaShowtime showtime;
+  final VoidCallback? onBuyPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final textTheme = theme.textTheme;
+
+    final details = <String>[];
+    final cinemaName = htmlToPlainText(showtime.cinemaId).replaceAll('\n', ', ');
+    if (cinemaName.trim().isNotEmpty) {
+      details.add(cinemaName.trim());
+    }
+    if (showtime.endTime.trim().isNotEmpty) {
+      details.add('До ${showtime.endTime.trim()}');
+    }
+
+    final timeParts = <String>[];
+    if (showtime.time.trim().isNotEmpty) {
+      timeParts.add(showtime.time.trim());
+    }
+    if (showtime.room.trim().isNotEmpty) {
+      timeParts.add(showtime.room.trim());
+    }
+    if (showtime.format.trim().isNotEmpty) {
+      timeParts.add(showtime.format.trim());
+    }
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 12),
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        border: Border.all(color: colorScheme.primary.withOpacity(0.15)),
+        borderRadius: BorderRadius.circular(16),
+        color: colorScheme.primary.withOpacity(0.05),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (timeParts.isNotEmpty)
+            Text(
+              timeParts.join(' • '),
+              style: (textTheme.titleSmall ?? const TextStyle()).copyWith(
+                fontWeight: FontWeight.w600,
+                color: colorScheme.onSurface,
+              ),
+            ),
+          if (details.isNotEmpty) ...[
+            const SizedBox(height: 6),
+            Text(
+              details.join('\n'),
+              style: (textTheme.bodyMedium ?? const TextStyle()).copyWith(
+                color: colorScheme.onSurface.withOpacity(0.75),
+                height: 1.3,
+              ),
+            ),
+          ],
+          if (onBuyPressed != null) ...[
+            const SizedBox(height: 12),
+            Align(
+              alignment: Alignment.centerRight,
+              child: TextButton.icon(
+                onPressed: onBuyPressed,
+                icon: const Icon(Icons.shopping_bag_outlined),
+                label: const Text('Купить билет'),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../afisha/afisha_screen.dart';
+import '../cinema/cinema_screen.dart';
 import '../events/events_screen.dart';
 import '../news/news_screen.dart';
 
@@ -18,6 +19,7 @@ class _HomeScreenState extends State<HomeScreen> {
     NewsScreen(),
     EventsScreen(),
     AfishaScreen(),
+    CinemaScreen(),
   ];
 
   @override
@@ -47,6 +49,7 @@ class _HomeScreenState extends State<HomeScreen> {
           BottomNavigationBarItem(icon: Icon(Icons.article), label: 'Новости'),
           BottomNavigationBarItem(icon: Icon(Icons.event), label: 'События'),
           BottomNavigationBarItem(icon: Icon(Icons.local_activity), label: 'Афиша'),
+          BottomNavigationBarItem(icon: Icon(Icons.movie), label: 'Кино'),
         ],
       ),
     );


### PR DESCRIPTION
## Summary
- add a cinema section to the home navigation and load films from the public API
- implement models and a service to parse cinema films with their showtimes
- build a cinema screen with film cards that group sessions and open ticket links

## Testing
- flutter test *(fails: `flutter` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc5d4292948326af6a5692e239bcad