### PR TITLE
Refine cinema film card layout

### DIFF
--- a/lib/features/cinema/models/cinema_film.dart
+++ b/lib/features/cinema/models/cinema_film.dart
@@ -13,6 +13,7 @@ class CinemaFilm {
     this.time,
     this.description,
     this.year,
+    this.country,
     this.poster,
     this.ratingVotes,
     this.replyCount,
@@ -30,6 +31,7 @@ class CinemaFilm {
   final String? time;
   final String? description;
   final String? year;
+  final String? country;
   final String? poster;
   final int? ratingVotes;
   final int? replyCount;
@@ -55,6 +57,9 @@ class CinemaFilm {
       replyCount: _parseInt(json['replys']),
       description: filmdata is Map ? _nullableString(filmdata['description']) : null,
       year: filmdata is Map ? _nullableString(filmdata['year']) : null,
+      country: filmdata is Map
+          ? _nullableString(filmdata['country'] ?? filmdata['countries'])
+          : null,
       poster: filmdata is Map ? _nullableString(filmdata['poster']) : null,
       showtimes: _parseShowtimes(json['showtimes']),
     );


### PR DESCRIPTION
## Summary
- restyle the cinema film card to mirror the event detail layout with textual metadata
- remove the showtime schedule table and related grouping logic from the card
- add support for the country field in the cinema film model for display

## Testing
- `flutter test` *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc77069ae48326824f48068abc18d7