### PR TITLE
Read country field from film data

### DIFF
--- a/lib/features/cinema/models/cinema_film.dart
+++ b/lib/features/cinema/models/cinema_film.dart
@@ -57,9 +57,8 @@ class CinemaFilm {
       replyCount: _parseInt(json['replys']),
       description: filmdata is Map ? _nullableString(filmdata['description']) : null,
       year: filmdata is Map ? _nullableString(filmdata['year']) : null,
-      country: filmdata is Map
-          ? _nullableString(filmdata['country'] ?? filmdata['countries'])
-          : null,
+      country:
+          filmdata is Map ? _nullableString(filmdata['country']) : null,
       poster: filmdata is Map ? _nullableString(filmdata['poster']) : null,
       showtimes: _parseShowtimes(json['showtimes']),
     );


### PR DESCRIPTION
## Summary
- read the `country` field directly from the nested `filmdata` map when constructing `CinemaFilm`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc7a63bbac8326be7b4c0fd2aa1268