### PR TITLE
Fix cinema film country parsing

### DIFF
--- a/lib/features/cinema/models/cinema_film.dart
+++ b/lib/features/cinema/models/cinema_film.dart
@@ -68,14 +68,30 @@ class CinemaFilm {
   }
 
   static String? _resolveCountry(dynamic filmdata, dynamic kpData) {
-    final countryFromFilmdata =
-        filmdata is Map ? _parseCountries(filmdata['country'] ?? filmdata['countries']) : null;
-    if (countryFromFilmdata != null) {
-      return countryFromFilmdata;
+    if (filmdata is Map) {
+      final directCountry =
+          _parseCountries(filmdata['country'] ?? filmdata['countries']);
+      if (directCountry != null) {
+        return directCountry;
+      }
+
+      final nestedKpData = filmdata['kp_data'] ?? filmdata['kpData'];
+      if (nestedKpData != null) {
+        final nestedCountry = _parseCountries(
+          nestedKpData is Map
+              ? nestedKpData['countries'] ?? nestedKpData['country'] ?? nestedKpData
+              : nestedKpData,
+        );
+        if (nestedCountry != null) {
+          return nestedCountry;
+        }
+      }
     }
 
-    if (kpData is Map) {
-      final countryFromKp = _parseCountries(kpData['countries']);
+    if (kpData != null) {
+      final countryFromKp = kpData is Map
+          ? _parseCountries(kpData['countries'] ?? kpData['country'] ?? kpData)
+          : _parseCountries(kpData);
       if (countryFromKp != null) {
         return countryFromKp;
       }


### PR DESCRIPTION
## Summary
- extend country resolution to cover nested filmdata.kp_data entries
- add fallbacks for additional kpData country representations

## Testing
- flutter test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cc7edf94808326893a3ef7f8f56089