### PR TITLE
Normalize cinema id comparisons for cinema filter

### DIFF
--- a/lib/features/cinema/cinema_screen.dart
+++ b/lib/features/cinema/cinema_screen.dart
@@ -13,16 +13,22 @@ class CinemaScreen extends StatefulWidget {
   State<CinemaScreen> createState() => _CinemaScreenState();
 }
 
-class _CinemaScreenState extends State<CinemaScreen> {
+class _CinemaScreenState extends State<CinemaScreen>
+    with SingleTickerProviderStateMixin {
   late CinemaApiService _api;
   List<CinemaFilm> _films = [];
   bool _isLoading = true;
   String? _error;
+  List<String?> _cinemaFilters = const [null];
+  String? _selectedCinemaId;
+  late TabController _tabController;
 
   @override
   void initState() {
     super.initState();
     _api = widget.apiService ?? CinemaApiService();
+    _tabController = TabController(length: _cinemaFilters.length, vsync: this);
+    _tabController.addListener(_onTabChanged);
     _loadFilms();
   }
 
@@ -33,6 +39,13 @@ class _CinemaScreenState extends State<CinemaScreen> {
       _api = widget.apiService ?? CinemaApiService();
       _loadFilms();
     }
+  }
+
+  @override
+  void dispose() {
+    _tabController.removeListener(_onTabChanged);
+    _tabController.dispose();
+    super.dispose();
   }
 
   Future<void> _loadFilms({bool refresh = false}) async {
@@ -50,9 +63,18 @@ class _CinemaScreenState extends State<CinemaScreen> {
     try {
       final films = await _api.fetchFilms();
       if (!mounted) return;
+      final filters = _buildCinemaFilters(films);
+      final nextSelectedId =
+          _selectedCinemaId != null && filters.contains(_selectedCinemaId)
+              ? _selectedCinemaId
+              : null;
+      final nextIndex = filters.indexOf(nextSelectedId);
       setState(() {
         _films = films;
+        _cinemaFilters = filters;
+        _selectedCinemaId = nextSelectedId;
       });
+      _configureTabController(filters.length, nextIndex >= 0 ? nextIndex : 0);
     } catch (e) {
       if (!mounted) return;
       setState(() {
@@ -67,6 +89,100 @@ class _CinemaScreenState extends State<CinemaScreen> {
   }
 
   Future<void> _handleRefresh() => _loadFilms(refresh: true);
+
+  List<String?> _buildCinemaFilters(List<CinemaFilm> films) {
+    final ids = <String>{};
+    for (final film in films) {
+      for (final showtime in film.showtimes) {
+        final id = _normalizeCinemaId(showtime.cinemaId);
+        if (id.isNotEmpty) {
+          ids.add(id);
+        }
+      }
+    }
+    final sorted = ids.toList()..sort();
+    return [null, ...sorted];
+  }
+
+  String _normalizeCinemaId(String? value) {
+    if (value == null) {
+      return '';
+    }
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) {
+      return '';
+    }
+    return trimmed;
+  }
+
+  void _configureTabController(int length, int index) {
+    final safeLength = length > 0 ? length : 1;
+    final clampedIndex = index < 0
+        ? 0
+        : index >= safeLength
+            ? safeLength - 1
+            : index;
+    if (_tabController.length == safeLength) {
+      if (_tabController.index != clampedIndex) {
+        _tabController.index = clampedIndex;
+      }
+      return;
+    }
+    _tabController
+      ..removeListener(_onTabChanged)
+      ..dispose();
+    _tabController = TabController(
+      length: safeLength,
+      initialIndex: clampedIndex,
+      vsync: this,
+    );
+    _tabController.addListener(_onTabChanged);
+  }
+
+  void _onTabChanged() {
+    if (_tabController.index < 0 ||
+        _tabController.index >= _cinemaFilters.length) {
+      return;
+    }
+    final selected = _cinemaFilters[_tabController.index];
+    if (_selectedCinemaId != selected) {
+      setState(() {
+        _selectedCinemaId = selected;
+      });
+    }
+  }
+
+  Widget _buildFilterTabBar(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final unselectedColor = colorScheme.onSurface.withOpacity(0.65);
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: colorScheme.surface,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: colorScheme.outline.withOpacity(0.2)),
+        ),
+        child: TabBar(
+          controller: _tabController,
+          isScrollable: true,
+          labelColor: colorScheme.onPrimary,
+          unselectedLabelColor: unselectedColor,
+          indicator: BoxDecoration(
+            color: colorScheme.primary,
+            borderRadius: BorderRadius.circular(10),
+          ),
+          indicatorPadding: const EdgeInsets.symmetric(vertical: 4, horizontal: 4),
+          labelStyle: const TextStyle(fontWeight: FontWeight.w600),
+          tabs: [
+            for (final id in _cinemaFilters)
+              Tab(text: id == null ? 'Все кинотеатры' : id),
+          ],
+        ),
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -103,14 +219,40 @@ class _CinemaScreenState extends State<CinemaScreen> {
       );
     }
 
+    final filteredFilms = _selectedCinemaId == null
+        ? _films
+        : _films
+            .where(
+              (film) => film.showtimes.any(
+                (show) => _normalizeCinemaId(show.cinemaId) == _selectedCinemaId,
+              ),
+            )
+            .toList();
+
+    final itemCount = filteredFilms.isEmpty ? 2 : filteredFilms.length + 1;
+
     return RefreshIndicator(
       onRefresh: _handleRefresh,
       child: ListView.separated(
         padding: const EdgeInsets.fromLTRB(0, 16, 0, 24),
         physics: const AlwaysScrollableScrollPhysics(),
-        itemCount: _films.length,
+        itemCount: itemCount,
         itemBuilder: (context, index) {
-          final film = _films[index];
+          if (index == 0) {
+            return _buildFilterTabBar(context);
+          }
+          if (filteredFilms.isEmpty) {
+            return const Padding(
+              padding: EdgeInsets.symmetric(horizontal: 16, vertical: 32),
+              child: Center(
+                child: Text(
+                  'Нет сеансов для выбранного кинотеатра',
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            );
+          }
+          final film = filteredFilms[index - 1];
           return CinemaFilmCard(film: film);
         },
         separatorBuilder: (_, __) => const SizedBox(height: 16),


### PR DESCRIPTION
## Summary
- normalize cinema ids before storing filter tabs and when matching showtimes so the selected tab displays the correct films

## Testing
- not run (flutter is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cc878c5a9083269937439076c2c395