### PR TITLE
Fix cinema loading indicator visibility

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -47,6 +47,8 @@ class _MyAppState extends State<MyApp> {
           elevation: 0,
           centerTitle: false,
         ),
+        progressIndicatorTheme:
+            base.progressIndicatorTheme.copyWith(color: _primary),
         tabBarTheme: TabBarThemeData(
           labelColor: _primary,
           unselectedLabelColor: Colors.black54,


### PR DESCRIPTION
## Summary
- ensure progress indicators use the primary brand color so loading states remain visible on light backgrounds

## Testing
- not run (Flutter SDK is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cc8e7b264c8326bfc3b68d178fb9c2