### PR TITLE
chore: bump app version to 1.0.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: m_club
 description: M-Club mobile app
 publish_to: "none"
-version: 0.1.0+1
+version: 1.0.1+1
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
## Summary
- bump the Flutter application version to 1.0.1 in preparation for release

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ccb51db1a4832699b9843e2928aa92