### PR TITLE
Pass category filter to news detail pagination

### DIFF
--- a/lib/features/news/news_detail_screen.dart
+++ b/lib/features/news/news_detail_screen.dart
@@ -9,10 +9,12 @@ class NewsDetailScreen extends StatefulWidget {
     super.key,
     required this.initialItems,
     required this.initialIndex,
+    this.categoryId,
   });
 
   final List<NewsItem> initialItems;
   final int initialIndex;
+  final String? categoryId;
 
   @override
   State<NewsDetailScreen> createState() => _NewsDetailScreenState();
@@ -27,10 +29,12 @@ class _NewsDetailScreenState extends State<NewsDetailScreen> {
   int _page = 1;
   int _pages = 1;
   late PageController _pageController;
+  late final String? _categoryId;
 
   @override
   void initState() {
     super.initState();
+    _categoryId = widget.categoryId;
     _items = List.of(widget.initialItems);
     _currentIndex = widget.initialIndex;
     _pageController = PageController(initialPage: _currentIndex);
@@ -58,7 +62,10 @@ class _NewsDetailScreenState extends State<NewsDetailScreen> {
       _error = null;
     });
     try {
-      final page = await _api.fetchNews(page: _page);
+      final page = await _api.fetchNews(
+        page: _page,
+        categoryId: _categoryId,
+      );
       setState(() {
         _items.addAll(page.items);
         _page = page.page + 1;

--- a/lib/features/news/news_list.dart
+++ b/lib/features/news/news_list.dart
@@ -152,6 +152,7 @@ class _NewsListState extends State<NewsList> {
                   builder: (_) => NewsDetailScreen(
                     initialItems: _items,
                     initialIndex: index,
+                    categoryId: widget.categoryId,
                   ),
                 ),
               );


### PR DESCRIPTION
## Summary
- add an optional category filter parameter to `NewsDetailScreen` and preserve it in state
- ensure detail pagination requests include the category and propagate it from the news list

## Testing
- flutter test *(fails: `flutter` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ccb8fa09848326bbc79c656f0fc72b