### PR TITLE
Guard post-await setState calls

### DIFF
--- a/lib/features/events/events_list.dart
+++ b/lib/features/events/events_list.dart
@@ -66,21 +66,23 @@ class _EventsListState extends State<EventsList> {
         page: _page,
         categoryId: widget.categoryId,
       );
+      if (!mounted) return;
       setState(() {
         _items.addAll(page.items);
         _page = page.page + 1;
         _pages = page.pages;
       });
     } catch (e) {
+      if (!mounted) return;
       setState(() {
         _error = 'Ошибка загрузки';
       });
     } finally {
-      if (mounted) {
-        setState(() => _isLoading = false);
-      } else {
+      if (!mounted) {
         _isLoading = false;
+        return;
       }
+      setState(() => _isLoading = false);
     }
   }
 

--- a/lib/features/news/news_detail_screen.dart
+++ b/lib/features/news/news_detail_screen.dart
@@ -66,6 +66,7 @@ class _NewsDetailScreenState extends State<NewsDetailScreen> {
         page: _page,
         categoryId: _categoryId,
       );
+      if (!mounted) return;
       setState(() {
         _items.addAll(page.items);
         _page = page.page + 1;
@@ -75,14 +76,15 @@ class _NewsDetailScreenState extends State<NewsDetailScreen> {
       if (e.toString().contains('No news items')) {
         _pages = _page - 1;
       } else {
-        if (mounted) setState(() => _error = 'Ошибка загрузки');
+        if (!mounted) return;
+        setState(() => _error = 'Ошибка загрузки');
       }
     } finally {
-      if (mounted) {
-        setState(() => _isLoading = false);
-      } else {
+      if (!mounted) {
         _isLoading = false;
+        return;
       }
+      setState(() => _isLoading = false);
     }
   }
 

--- a/lib/features/news/news_list.dart
+++ b/lib/features/news/news_list.dart
@@ -58,21 +58,23 @@ class _NewsListState extends State<NewsList> {
         page: _page,
         categoryId: widget.categoryId,
       );
+      if (!mounted) return;
       setState(() {
         _items.addAll(page.items);
         _page = page.page + 1;
         _pages = page.pages;
       });
     } catch (e) {
+      if (!mounted) return;
       setState(() {
         _error = 'Ошибка загрузки';
       });
     } finally {
-      if (mounted) {
-        setState(() => _isLoading = false);
-      } else {
+      if (!mounted) {
         _isLoading = false;
+        return;
       }
+      setState(() => _isLoading = false);
     }
   }
 


### PR DESCRIPTION
## Summary
- guard post-await and error setState calls in news and events loaders with mounted checks
- keep async fetch results in local variables while avoiding updates to disposed state

## Testing
- flutter analyze *(fails: `flutter` command not found in container)*
- flutter test *(fails: `flutter` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ccb9c7c5348326979477d23353eb9b