### PR TITLE
Fix Android MainActivity to extend FlutterActivity

### DIFF
--- a/android/app/src/main/kotlin/com/gorodmore/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/gorodmore/app/MainActivity.kt
@@ -2,11 +2,11 @@ package com.gorodmore.app
 
 import android.content.Context
 import android.util.Log
-import com.ryanheise.audioservice.AudioServiceActivity
+import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
 
-class MainActivity : AudioServiceActivity() {
+class MainActivity : FlutterActivity() {
 
     companion object {
         private const val CHANNEL_NAME = "flutter_method_channel"


### PR DESCRIPTION
## Summary
- replace the AudioServiceActivity dependency with the stock FlutterActivity to resolve missing import issues

## Testing
- not run (flutter CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ccc1d632788326a4e5ba6cc25aa939