### PR TITLE
Adjust home app bar ticker layout

### DIFF
--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -54,28 +54,29 @@ class _HomeScreenState extends State<HomeScreen> {
         centerTitle: true,
         elevation: 0,
         title: Row(
-          mainAxisSize: MainAxisSize.min,
+          mainAxisSize: MainAxisSize.max,
           children: [
             Image.asset(
               'assets/images/logo_light_mobile.png',
               height: 30,
               fit: BoxFit.contain,
             ),
-            FutureBuilder<List<CurrencyRate>>(
-              future: _ratesFuture,
-              builder: (context, snapshot) {
-                final rates = snapshot.data ?? const [];
-                if (rates.isEmpty) {
-                  return const SizedBox.shrink();
-                }
-                return Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    const SizedBox(width: 8),
-                    _RatesTicker(rates: rates),
-                  ],
-                );
-              },
+            const SizedBox(width: 8),
+            Expanded(
+              child: FutureBuilder<List<CurrencyRate>>(
+                future: _ratesFuture,
+                builder: (context, snapshot) {
+                  final rates = snapshot.data ?? const [];
+                  if (rates.isEmpty) {
+                    return const SizedBox.shrink();
+                  }
+                  return FittedBox(
+                    fit: BoxFit.scaleDown,
+                    alignment: Alignment.centerLeft,
+                    child: _RatesTicker(rates: rates),
+                  );
+                },
+              ),
             ),
           ],
         ),


### PR DESCRIPTION
## Summary
- allow the home app bar title row to expand fully and maintain spacing between the logo and ticker
- constrain the rates ticker with Expanded and let it scale down with FittedBox to avoid overflow on small widths

## Testing
- `flutter test` *(fails: flutter tooling is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ccc88700e483269bf77e1e2a170bb1