### PR TITLE
Add video section with API and UI parity to news

### DIFF
--- a/lib/core/services/video_api_service.dart
+++ b/lib/core/services/video_api_service.dart
@@ -1,0 +1,269 @@
+import 'dart:ui' as ui;
+
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+
+import '../../features/video/models/video_category.dart';
+import '../../features/video/models/video_item.dart';
+import '../../features/video/models/video_page.dart';
+
+class VideoApiService {
+  static final VideoApiService _instance = VideoApiService._internal();
+  factory VideoApiService() => _instance;
+  VideoApiService._internal() {
+    _dio = Dio(
+      BaseOptions(
+        baseUrl: 'https://gorodmore.ru/api/',
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept-Language': _resolveLang(),
+        },
+        connectTimeout: const Duration(seconds: 10),
+        receiveTimeout: const Duration(seconds: 10),
+      ),
+    );
+  }
+
+  late Dio _dio;
+
+  @visibleForTesting
+  Dio get dio => _dio;
+
+  /// Получить список видеокатегорий (feeds)
+  Future<List<VideoCategory>> fetchFeeds() async {
+    final res = await _dio.get('video/feeds');
+    final raw = res.data;
+    final payload = _unwrapResponse(raw);
+
+    final categories = <VideoCategory>[];
+    final data = _extractList(payload) ?? _extractList(raw);
+    if (data != null) {
+      for (final item in data) {
+        if (item is Map<String, dynamic>) {
+          categories.add(VideoCategory.fromJson(item));
+        }
+      }
+    } else if (payload is Map) {
+      for (final entry in payload.entries) {
+        if (entry.value is Map<String, dynamic>) {
+          categories
+              .add(VideoCategory.fromJson(entry.value as Map<String, dynamic>));
+        }
+      }
+    }
+    return categories;
+  }
+
+  /// Получить список видео
+  Future<VideoPage> fetchVideos({
+    int page = 1,
+    int perPage = 20,
+    String? categoryId,
+  }) async {
+    final params = <String, dynamic>{'page': page, 'perPage': perPage};
+    if (categoryId?.isNotEmpty ?? false) {
+      params['category_id'] = categoryId;
+    }
+
+    final res = await _dio.get('video', queryParameters: params);
+    final raw = res.data;
+    final payload = _unwrapResponse(raw);
+
+    final rawItems = _extractList(payload) ?? _extractList(raw);
+
+    if (rawItems == null || rawItems.isEmpty) {
+      throw Exception('No video items found in response');
+    }
+
+    final items = <VideoItem>[];
+    for (final item in rawItems) {
+      if (item is Map<String, dynamic>) {
+        items.add(VideoItem.fromJson(item));
+      }
+    }
+
+    if (items.isEmpty) {
+      throw Exception('No video items could be parsed');
+    }
+
+    final pagination = _extractPagination(payload) ??
+        _extractPagination(raw) ??
+        const {};
+
+    final pageNum =
+        _parseInt(pagination['page'] ?? pagination['current_page']) ?? page;
+
+    final perPageVal = _parseInt(
+          pagination['perPage'] ?? pagination['per_page'] ?? pagination['limit'],
+        ) ??
+        perPage;
+
+    final total = _parseInt(
+          pagination['total'] ??
+              pagination['total_items'] ??
+              pagination['totalItems'] ??
+              pagination['count'],
+        ) ??
+        items.length;
+
+    int? pages = _parseInt(
+      pagination['pages'] ??
+          pagination['last_page'] ??
+          pagination['total_pages'] ??
+          pagination['lastPage'],
+    );
+    final safePerPage = perPageVal > 0
+        ? perPageVal
+        : (items.isNotEmpty ? items.length : 1);
+    if (pages == null && safePerPage > 0) {
+      pages = (total / safePerPage).ceil();
+    }
+
+    final pagesCount = pages ?? (total / safePerPage).ceil();
+
+    return VideoPage(
+      items: items,
+      page: pageNum,
+      pages: pagesCount,
+      total: total,
+    );
+  }
+
+  String _resolveLang() {
+    final code = ui.PlatformDispatcher.instance.locale.languageCode
+        .toLowerCase();
+    return code == 'ru' ? 'ru' : 'en';
+  }
+
+  dynamic _unwrapResponse(dynamic raw) {
+    if (raw is Map) {
+      for (final key in const ['data', 'result', 'payload']) {
+        if (raw[key] != null) {
+          return raw[key];
+        }
+      }
+    }
+    return raw;
+  }
+
+  List<dynamic>? _extractList(dynamic data) {
+    if (data is List) {
+      return data;
+    }
+    if (data is Map) {
+      for (final key
+          in const ['items', 'videos', 'video', 'feeds', 'list', 'results', 'data']) {
+        if (data.containsKey(key)) {
+          final list = _extractList(data[key]);
+          if (list != null) {
+            return list;
+          }
+        }
+      }
+
+      final mapValues = <Map<String, dynamic>>[];
+      data.forEach((key, value) {
+        final keyStr = key.toString();
+        if ({'pagination', 'meta', '_meta', 'links', '_links'}.contains(keyStr)) {
+          return;
+        }
+        if (value is Map<String, dynamic>) {
+          mapValues.add(value);
+        }
+      });
+      if (mapValues.isNotEmpty) {
+        return mapValues;
+      }
+
+      for (final entry in data.entries) {
+        final keyStr = entry.key.toString();
+        if ({'pagination', 'meta', '_meta', 'links', '_links'}.contains(keyStr)) {
+          continue;
+        }
+        final list = _extractList(entry.value);
+        if (list != null) {
+          return list;
+        }
+      }
+    }
+    return null;
+  }
+
+  Map<String, dynamic>? _extractPagination(dynamic source) {
+    if (source is Map) {
+      for (final key in const ['pagination', 'meta']) {
+        final value = source[key];
+        if (value is Map) {
+          if (_looksLikePagination(value)) {
+            return value.map((k, v) => MapEntry(k.toString(), v));
+          }
+          final nested = _extractPagination(value);
+          if (nested != null) {
+            return nested;
+          }
+        }
+      }
+
+      for (final entry in source.entries) {
+        final value = entry.value;
+        if (value is Map) {
+          if (_looksLikePagination(value)) {
+            return value.map((k, v) => MapEntry(k.toString(), v));
+          }
+          final nested = _extractPagination(value);
+          if (nested != null) {
+            return nested;
+          }
+        }
+      }
+    }
+    return null;
+  }
+
+  bool _looksLikePagination(Map<dynamic, dynamic> map) {
+    const keys = {
+      'page',
+      'current_page',
+      'currentPage',
+      'per_page',
+      'perPage',
+      'limit',
+      'total',
+      'total_items',
+      'totalItems',
+      'count',
+      'pages',
+      'last_page',
+      'lastPage',
+      'total_pages',
+      'totalPages',
+    };
+    for (final key in map.keys) {
+      if (keys.contains(key.toString())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  int? _parseInt(dynamic value) {
+    if (value is num) {
+      return value.toInt();
+    }
+    if (value is String) {
+      final trimmed = value.trim();
+      if (trimmed.isEmpty) {
+        return null;
+      }
+      final parsed = int.tryParse(trimmed);
+      if (parsed != null) {
+        return parsed;
+      }
+      final asDouble = double.tryParse(trimmed);
+      if (asDouble != null) {
+        return asDouble.toInt();
+      }
+    }
+    return null;
+  }
+}

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -6,6 +6,7 @@ import '../afisha/afisha_screen.dart';
 import '../cinema/cinema_screen.dart';
 import '../events/events_screen.dart';
 import '../news/news_screen.dart';
+import '../video/video_screen.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -23,6 +24,7 @@ class _HomeScreenState extends State<HomeScreen> {
   static const _primary = Color(0xFF182857);
   static const List<Widget> _pages = [
     NewsScreen(),
+    VideoScreen(),
     EventsScreen(),
     AfishaScreen(),
     CinemaScreen(),
@@ -91,6 +93,10 @@ class _HomeScreenState extends State<HomeScreen> {
         onTap: (i) => setState(() => _index = i),
         items: const [
           BottomNavigationBarItem(icon: Icon(Icons.article), label: 'Новости'),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.ondemand_video),
+            label: 'Видео',
+          ),
           BottomNavigationBarItem(icon: Icon(Icons.event), label: 'События'),
           BottomNavigationBarItem(icon: Icon(Icons.local_activity), label: 'Афиша'),
           BottomNavigationBarItem(icon: Icon(Icons.movie), label: 'Кино'),

--- a/lib/features/video/models/video_category.dart
+++ b/lib/features/video/models/video_category.dart
@@ -1,0 +1,94 @@
+import 'video_rubric.dart';
+
+class VideoCategory {
+  final String id;
+  final String name;
+  final List<VideoRubric> rubrics;
+
+  VideoCategory({
+    required this.id,
+    required this.name,
+    required this.rubrics,
+  });
+
+  factory VideoCategory.fromJson(Map<String, dynamic> json) {
+    final rubrics = <VideoRubric>[];
+    final rawRubrics = json['rubrics'];
+    if (rawRubrics is List) {
+      for (final r in rawRubrics) {
+        if (r is Map<String, dynamic>) {
+          rubrics.add(VideoRubric.fromJson(r));
+        }
+      }
+    }
+    return VideoCategory(
+      id: _extractCategoryId(json) ?? '',
+      name: json['name']?.toString() ?? '',
+      rubrics: rubrics,
+    );
+  }
+}
+
+String? _extractCategoryId(Map<String, dynamic> json) {
+  final primaryId = _extractFirstString(json, const ['id']);
+  if (primaryId != null) {
+    return primaryId;
+  }
+
+  final feedId = _extractFirstString(
+    json,
+    const ['feed_id', 'feedId', 'feedID', 'feed-id', 'feedid'],
+  );
+  if (feedId != null) {
+    return feedId;
+  }
+
+  for (final entry in json.entries) {
+    final normalizedKey = _normalizeKey(entry.key.toString());
+    if (normalizedKey == 'id' || normalizedKey == 'feedid') {
+      final valueStr = _valueToString(entry.value);
+      if (valueStr != null) {
+        return valueStr;
+      }
+    }
+  }
+
+  return null;
+}
+
+String? _extractFirstString(Map<String, dynamic> json, List<String> keys) {
+  for (final key in keys) {
+    final valueStr = _valueToString(json[key]);
+    if (valueStr != null) {
+      return valueStr;
+    }
+  }
+
+  final normalizedKeys = keys.map(_normalizeKey).toSet();
+  for (final entry in json.entries) {
+    final normalizedKey = _normalizeKey(entry.key.toString());
+    if (normalizedKeys.contains(normalizedKey)) {
+      final valueStr = _valueToString(entry.value);
+      if (valueStr != null) {
+        return valueStr;
+      }
+    }
+  }
+
+  return null;
+}
+
+String _normalizeKey(String key) {
+  return key.toLowerCase().replaceAll(RegExp(r'[\s_-]'), '');
+}
+
+String? _valueToString(dynamic value) {
+  if (value == null) {
+    return null;
+  }
+  final str = value.toString();
+  if (str.isEmpty) {
+    return null;
+  }
+  return str;
+}

--- a/lib/features/video/models/video_item.dart
+++ b/lib/features/video/models/video_item.dart
@@ -1,0 +1,57 @@
+import 'video_rubric.dart';
+
+class VideoItem {
+  final String id;
+  final String title;
+  final String contentPreview;
+  final String contentFull;
+  final String image;
+  final String url;
+  final String author;
+  final DateTime? published;
+  final VideoRubric? rubric;
+  final String videoFrame;
+
+  VideoItem({
+    required this.id,
+    required this.title,
+    required this.contentPreview,
+    required this.contentFull,
+    required this.image,
+    required this.url,
+    required this.author,
+    required this.videoFrame,
+    this.published,
+    this.rubric,
+  });
+
+  factory VideoItem.fromJson(Map<String, dynamic> json) {
+    VideoRubric? rubric;
+    final r = json['rubric'];
+    if (r is Map<String, dynamic>) {
+      rubric = VideoRubric.fromJson(r);
+    }
+
+    DateTime? published;
+    final p = json['published'] ?? json['published_at'] ?? json['date'];
+    if (p != null) {
+      published = DateTime.tryParse(p.toString());
+    }
+
+    return VideoItem(
+      id: json['id']?.toString() ?? '',
+      title: json['title']?.toString() ?? '',
+      contentPreview:
+          (json['content_preview'] ?? json['preview'] ?? json['introtext'] ?? json['short_content'] ?? '')
+              .toString(),
+      contentFull:
+          (json['content_full'] ?? json['content'] ?? json['fulltext'] ?? json['full_text'] ?? '').toString(),
+      image: (json['image'] ?? json['image_url'] ?? json['photo_url'] ?? '').toString(),
+      url: (json['url'] ?? json['link'] ?? '').toString(),
+      author: (json['author'] ?? '').toString(),
+      videoFrame: (json['video_frame'] ?? json['videoFrame'] ?? '').toString(),
+      published: published,
+      rubric: rubric,
+    );
+  }
+}

--- a/lib/features/video/models/video_page.dart
+++ b/lib/features/video/models/video_page.dart
@@ -1,0 +1,15 @@
+import 'video_item.dart';
+
+class VideoPage {
+  final List<VideoItem> items;
+  final int page;
+  final int pages;
+  final int total;
+
+  VideoPage({
+    required this.items,
+    required this.page,
+    required this.pages,
+    required this.total,
+  });
+}

--- a/lib/features/video/models/video_rubric.dart
+++ b/lib/features/video/models/video_rubric.dart
@@ -1,0 +1,19 @@
+class VideoRubric {
+  final String id;
+  final String name;
+  final String slug;
+
+  VideoRubric({
+    required this.id,
+    required this.name,
+    required this.slug,
+  });
+
+  factory VideoRubric.fromJson(Map<String, dynamic> json) {
+    return VideoRubric(
+      id: json['id']?.toString() ?? '',
+      name: json['name']?.toString() ?? '',
+      slug: json['slug']?.toString() ?? '',
+    );
+  }
+}

--- a/lib/features/video/video_article_view.dart
+++ b/lib/features/video/video_article_view.dart
@@ -1,0 +1,307 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_html/flutter_html.dart';
+import 'package:share_plus/share_plus.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../core/utils/html_utils.dart';
+import '../../core/utils/image_brightness.dart';
+import '../../core/utils/time_ago.dart';
+import 'models/video_item.dart';
+
+class VideoArticleView extends StatefulWidget {
+  const VideoArticleView({super.key, required this.item});
+
+  final VideoItem item;
+
+  @override
+  State<VideoArticleView> createState() => _VideoArticleViewState();
+}
+
+class _VideoArticleViewState extends State<VideoArticleView> {
+  final _scrollController = ScrollController();
+  bool _collapsed = false;
+  bool? _isPhotoDark;
+
+  double _textScaleFactor = 1.0;
+
+  static const double _expandedHeight = 320;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController.addListener(_onScroll);
+    _analyzePhoto();
+    _loadScaleFactor();
+  }
+
+  @override
+  void dispose() {
+    _scrollController.removeListener(_onScroll);
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _onScroll() {
+    if (!mounted) return;
+    final topPad = MediaQuery.of(context).padding.top;
+    final threshold = _expandedHeight - (kToolbarHeight + topPad);
+    final nowCollapsed =
+        _scrollController.positions.isNotEmpty &&
+            _scrollController.offset >= threshold;
+    if (nowCollapsed != _collapsed) {
+      setState(() => _collapsed = nowCollapsed);
+    }
+  }
+
+  Future<void> _analyzePhoto() async {
+    final url = widget.item.image;
+    if (url.isEmpty) return;
+    final dark = await isImageDark(url);
+    if (mounted) setState(() => _isPhotoDark = dark);
+  }
+
+  void _share() {
+    final link = widget.item.url;
+    final title = widget.item.title;
+    final text = [title, link].where((e) => e.trim().isNotEmpty).join('\n');
+    if (text.isNotEmpty) Share.share(text);
+  }
+
+  Future<void> _loadScaleFactor() async {
+    final prefs = await SharedPreferences.getInstance();
+    final saved = prefs.getDouble('video_text_scale') ?? 1.0;
+    if (mounted) setState(() => _textScaleFactor = saved);
+  }
+
+  Future<void> _changeScale(double delta) async {
+    setState(() {
+      _textScaleFactor = (_textScaleFactor + delta).clamp(0.5, 2.0);
+    });
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setDouble('video_text_scale', _textScaleFactor);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final item = widget.item;
+    final hasVideo = item.videoFrame.trim().isNotEmpty;
+    final dark = hasVideo ? true : (_isPhotoDark ?? true);
+    final iconColor =
+        _collapsed ? Colors.black87 : (dark ? Colors.white : Colors.black87);
+    final overlayStyle = _collapsed
+        ? SystemUiOverlayStyle.dark
+        : (dark ? SystemUiOverlayStyle.light : SystemUiOverlayStyle.dark);
+
+    final descPlain = htmlToPlainText(item.contentPreview);
+
+    final meta = [
+      if (item.published != null) timeAgo(item.published),
+      if (item.author.trim().isNotEmpty) item.author.trim(),
+    ].join(' · ');
+
+    return AnnotatedRegion<SystemUiOverlayStyle>(
+      value: overlayStyle,
+      child: Scaffold(
+        body: CustomScrollView(
+          controller: _scrollController,
+          slivers: [
+            SliverAppBar(
+              backgroundColor: Colors.white,
+              elevation: 0,
+              pinned: true,
+              expandedHeight: _expandedHeight,
+              leading: IconButton(
+                icon: Icon(Icons.arrow_back, color: iconColor),
+                onPressed: () => Navigator.of(context).pop(),
+                tooltip: 'Назад',
+              ),
+              actions: [
+                IconButton(
+                  icon: Text('A-', style: TextStyle(color: iconColor)),
+                  onPressed: () => _changeScale(-0.1),
+                  tooltip: 'Меньше',
+                ),
+                IconButton(
+                  icon: Text('A+', style: TextStyle(color: iconColor)),
+                  onPressed: () => _changeScale(0.1),
+                  tooltip: 'Больше',
+                ),
+                IconButton(
+                  icon: Icon(Icons.share, color: iconColor),
+                  onPressed: _share,
+                  tooltip: 'Поделиться',
+                ),
+              ],
+              systemOverlayStyle: overlayStyle,
+              flexibleSpace: FlexibleSpaceBar(
+                background: Stack(
+                  fit: StackFit.expand,
+                  children: [
+                    Hero(
+                      tag: item.id,
+                      child: _MediaContent(item: item),
+                    ),
+                    Positioned.fill(
+                      child: IgnorePointer(
+                        child: DecoratedBox(
+                          decoration: BoxDecoration(
+                            gradient: LinearGradient(
+                              begin: Alignment.topCenter,
+                              end: Alignment.bottomCenter,
+                              colors: [
+                                Colors.transparent,
+                                Colors.black.withOpacity(0.1),
+                                Colors.black.withOpacity(0.3),
+                                Colors.black.withOpacity(0.5),
+                              ],
+                              stops: const [0.5, 0.75, 0.9, 1.0],
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                    Positioned(
+                      left: 12,
+                      right: 12,
+                      bottom: 12,
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          if (item.rubric != null &&
+                              item.rubric!.name.isNotEmpty)
+                            Text(
+                              item.rubric!.name.toUpperCase(),
+                              style: const TextStyle(
+                                color: Colors.white70,
+                                fontSize: 14,
+                                fontWeight: FontWeight.w500,
+                                shadows: [
+                                  Shadow(
+                                    color: Colors.black54,
+                                    blurRadius: 4,
+                                    offset: Offset(0, 1),
+                                  )
+                                ],
+                              ),
+                            ),
+                          Text(
+                            item.title,
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                            style: const TextStyle(
+                              color: Colors.white,
+                              fontSize: 24,
+                              fontWeight: FontWeight.w600,
+                              height: 1.2,
+                              shadows: [
+                                Shadow(
+                                  color: Colors.black54,
+                                  blurRadius: 4,
+                                  offset: Offset(0, 1),
+                                )
+                              ],
+                            ),
+                          ),
+                          if (descPlain.isNotEmpty) ...[
+                            const SizedBox(height: 8),
+                            Text(
+                              descPlain,
+                              maxLines: 3,
+                              overflow: TextOverflow.ellipsis,
+                              style: const TextStyle(
+                                color: Colors.white,
+                                fontSize: 18,
+                                height: 1.25,
+                                shadows: [
+                                  Shadow(
+                                    color: Colors.black54,
+                                    blurRadius: 4,
+                                    offset: Offset(0, 1),
+                                  )
+                                ],
+                              ),
+                            ),
+                          ],
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            SliverToBoxAdapter(
+              child: Padding(
+                padding: const EdgeInsets.all(12),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    if (meta.isNotEmpty)
+                      Padding(
+                        padding: const EdgeInsets.only(bottom: 12),
+                        child: Text(
+                          meta,
+                          style: const TextStyle(
+                            fontSize: 16,
+                            color: Colors.grey,
+                          ),
+                        ),
+                      ),
+                    Html(
+                      data: item.contentFull,
+                      style: {
+                        '*': Style(fontSize: FontSize(18 * _textScaleFactor)),
+                        'p': Style(margin: Margins.only(top: 0, bottom: 12)),
+                        'ul': Style(margin: Margins.only(top: 0, bottom: 12)),
+                        'ol': Style(margin: Margins.only(top: 0, bottom: 12)),
+                      },
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            const SliverPadding(padding: EdgeInsets.only(bottom: 24)),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MediaContent extends StatelessWidget {
+  const _MediaContent({required this.item});
+
+  final VideoItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    if (item.videoFrame.trim().isNotEmpty) {
+      return Container(
+        color: Colors.black,
+        child: Html(
+          data: item.videoFrame,
+          style: {
+            'html': Style(margin: Margins.zero, padding: HtmlPaddings.zero),
+            'body': Style(margin: Margins.zero, padding: HtmlPaddings.zero),
+            'iframe': Style(
+              width: Width(100, Unit.percent),
+              height: Height(100, Unit.percent),
+            ),
+          },
+        ),
+      );
+    }
+
+    if (item.image.isEmpty) {
+      return Container(color: Colors.grey.shade200);
+    }
+
+    return CachedNetworkImage(
+      imageUrl: item.image,
+      fit: BoxFit.cover,
+      placeholder: (_, __) => Container(color: Colors.grey.shade200),
+      errorWidget: (_, __, ___) => Container(color: Colors.grey.shade200),
+    );
+  }
+}

--- a/lib/features/video/video_detail_screen.dart
+++ b/lib/features/video/video_detail_screen.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+
+import '../../core/services/video_api_service.dart';
+import 'models/video_item.dart';
+import 'video_article_view.dart';
+
+class VideoDetailScreen extends StatefulWidget {
+  const VideoDetailScreen({
+    super.key,
+    required this.initialItems,
+    required this.initialIndex,
+    this.categoryId,
+  });
+
+  final List<VideoItem> initialItems;
+  final int initialIndex;
+  final String? categoryId;
+
+  @override
+  State<VideoDetailScreen> createState() => _VideoDetailScreenState();
+}
+
+class _VideoDetailScreenState extends State<VideoDetailScreen> {
+  final _api = VideoApiService();
+  late List<VideoItem> _items;
+  late int _currentIndex;
+  bool _isLoading = false;
+  String? _error;
+  int _page = 1;
+  int _pages = 1;
+  late PageController _pageController;
+  late final String? _categoryId;
+
+  @override
+  void initState() {
+    super.initState();
+    _categoryId = widget.categoryId;
+    _items = List.of(widget.initialItems);
+    _currentIndex = widget.initialIndex;
+    _pageController = PageController(initialPage: _currentIndex);
+    _page = (_items.length / 20).ceil() + 1;
+    _pages = _page;
+  }
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  void _onPageChanged(int index) {
+    setState(() => _currentIndex = index);
+    if (index >= _items.length - 2) {
+      _loadMore();
+    }
+  }
+
+  Future<void> _loadMore() async {
+    if (_isLoading || _page > _pages) return;
+    setState(() {
+      _isLoading = true;
+      _error = null;
+    });
+    try {
+      final page = await _api.fetchVideos(
+        page: _page,
+        categoryId: _categoryId,
+      );
+      if (!mounted) return;
+      setState(() {
+        _items.addAll(page.items);
+        _page = page.page + 1;
+        _pages = page.pages;
+      });
+    } catch (e) {
+      if (e.toString().contains('No video items')) {
+        _pages = _page - 1;
+      } else {
+        if (!mounted) return;
+        setState(() => _error = 'Ошибка загрузки');
+      }
+    } finally {
+      if (!mounted) {
+        _isLoading = false;
+        return;
+      }
+      setState(() => _isLoading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Stack(
+        children: [
+          PageView.builder(
+            controller: _pageController,
+            itemCount: _items.length,
+            onPageChanged: _onPageChanged,
+            pageSnapping: true,
+            itemBuilder: (context, index) => VideoArticleView(
+              key: ValueKey(_items[index].id),
+              item: _items[index],
+            ),
+          ),
+          if (_isLoading)
+            const Positioned(
+              bottom: 16,
+              left: 0,
+              right: 0,
+              child: Center(child: CircularProgressIndicator()),
+            ),
+          if (_error != null)
+            Positioned(
+              bottom: 16,
+              left: 0,
+              right: 0,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(_error!),
+                  const SizedBox(height: 8),
+                  ElevatedButton(
+                    onPressed: _loadMore,
+                    child: const Text('Повторить'),
+                  ),
+                ],
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/video/video_list.dart
+++ b/lib/features/video/video_list.dart
@@ -1,0 +1,264 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+
+import '../../core/services/video_api_service.dart';
+import '../../core/utils/html_utils.dart';
+import '../../core/utils/time_ago.dart';
+import '../news/widgets/news_list_item_skeleton.dart';
+import 'models/video_item.dart';
+import 'video_detail_screen.dart';
+
+class VideoList extends StatefulWidget {
+  const VideoList({super.key, this.categoryId});
+
+  final String? categoryId;
+
+  @override
+  State<VideoList> createState() => _VideoListState();
+}
+
+class _VideoListState extends State<VideoList> {
+  final _api = VideoApiService();
+  final _scrollController = ScrollController();
+  final List<VideoItem> _items = [];
+  bool _isLoading = false;
+  String? _error;
+  int _page = 1;
+  int _pages = 1;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadMore();
+    _scrollController.addListener(_onScroll);
+  }
+
+  void _onScroll() {
+    if (_scrollController.position.extentAfter < 200) {
+      _loadMore();
+    }
+  }
+
+  Future<void> _refresh() async {
+    setState(() {
+      _items.clear();
+      _page = 1;
+      _pages = 1;
+      _error = null;
+    });
+    await _loadMore();
+  }
+
+  Future<void> _loadMore() async {
+    if (_isLoading || _page > _pages) return;
+    setState(() {
+      _isLoading = true;
+      _error = null;
+    });
+    try {
+      final page = await _api.fetchVideos(
+        page: _page,
+        categoryId: widget.categoryId,
+      );
+      if (!mounted) return;
+      setState(() {
+        _items.addAll(page.items);
+        _page = page.page + 1;
+        _pages = page.pages;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _error = 'Ошибка загрузки';
+      });
+    } finally {
+      if (!mounted) {
+        _isLoading = false;
+        return;
+      }
+      setState(() => _isLoading = false);
+    }
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_items.isEmpty) {
+      if (_isLoading) {
+        return ListView.separated(
+          itemCount: 5,
+          separatorBuilder: (_, __) => const Divider(height: 0),
+          itemBuilder: (_, __) => const NewsListItemSkeleton(),
+        );
+      }
+      if (_error != null) {
+        return Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(_error!),
+              const SizedBox(height: 8),
+              ElevatedButton(
+                onPressed: _loadMore,
+                child: const Text('Повторить'),
+              ),
+            ],
+          ),
+        );
+      }
+    }
+
+    final showBottom = _isLoading || _error != null;
+
+    return RefreshIndicator(
+      onRefresh: _refresh,
+      child: ListView.separated(
+        controller: _scrollController,
+        itemCount: _items.length + (showBottom ? 1 : 0),
+        separatorBuilder: (context, index) {
+          if (index >= _items.length - 1) {
+            return const SizedBox.shrink();
+          }
+          return const Divider(height: 0);
+        },
+        itemBuilder: (context, index) {
+          if (index >= _items.length) {
+            if (_isLoading) {
+              return const NewsListItemSkeleton();
+            } else {
+              return Padding(
+                padding: const EdgeInsets.symmetric(vertical: 16),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(_error ?? 'Ошибка'),
+                    const SizedBox(height: 8),
+                    ElevatedButton(
+                      onPressed: _loadMore,
+                      child: const Text('Повторить'),
+                    ),
+                  ],
+                ),
+              );
+            }
+          }
+          final item = _items[index];
+          return VideoListItem(
+            item: item,
+            onTap: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => VideoDetailScreen(
+                    initialItems: _items,
+                    initialIndex: index,
+                    categoryId: widget.categoryId,
+                  ),
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}
+
+class VideoListItem extends StatelessWidget {
+  const VideoListItem({super.key, required this.item, this.onTap});
+
+  final VideoItem item;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final imageHeight = MediaQuery.of(context).size.width * 0.6;
+    final previewPlain = htmlToPlainText(item.contentPreview);
+    return GestureDetector(
+      onTap: onTap,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (item.image.isNotEmpty)
+            Hero(
+              tag: item.id,
+              child: CachedNetworkImage(
+                imageUrl: item.image,
+                width: double.infinity,
+                height: imageHeight,
+                fit: BoxFit.cover,
+                placeholder: (_, __) => Container(
+                  height: imageHeight,
+                  color: Colors.grey.shade200,
+                ),
+                errorWidget: (_, __, ___) => Container(
+                  height: imageHeight,
+                  color: Colors.grey.shade200,
+                ),
+              ),
+            )
+          else
+            Container(
+              width: double.infinity,
+              height: imageHeight,
+              color: Colors.grey.shade200,
+            ),
+          Padding(
+            padding: const EdgeInsets.all(12),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (item.rubric != null && item.rubric!.name.isNotEmpty)
+                  Text(
+                    item.rubric!.name.toUpperCase(),
+                    style: const TextStyle(
+                      fontSize: 14,
+                      fontWeight: FontWeight.w500,
+                      color: Colors.grey,
+                    ),
+                  ),
+                Text(
+                  item.title,
+                  style: const TextStyle(
+                    fontSize: 20,
+                    fontWeight: FontWeight.w400,
+                    fontFamily: 'Roboto',
+                  ),
+                ),
+                if (previewPlain.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 8),
+                    child: Text(
+                      previewPlain,
+                      style: const TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w300,
+                        fontFamily: 'Roboto',
+                      ),
+                    ),
+                  ),
+                Padding(
+                  padding: const EdgeInsets.only(top: 12),
+                  child: Text(
+                    [
+                      if (item.published != null) timeAgo(item.published),
+                      if (item.author.trim().isNotEmpty) item.author,
+                    ].join(' · '),
+                    style: const TextStyle(
+                      fontSize: 16,
+                      color: Colors.grey,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/video/video_screen.dart
+++ b/lib/features/video/video_screen.dart
@@ -1,0 +1,136 @@
+import 'package:flutter/material.dart';
+
+import '../../core/services/video_api_service.dart';
+import 'models/video_category.dart';
+import 'video_list.dart';
+
+class VideoScreen extends StatefulWidget {
+  const VideoScreen({super.key});
+
+  @override
+  State<VideoScreen> createState() => _VideoScreenState();
+}
+
+class _VideoScreenState extends State<VideoScreen> {
+  final _api = VideoApiService();
+  List<VideoCategory> _categories = [];
+  bool _isLoading = true;
+  String? _error;
+  int _selectedIndex = 0;
+  TabController? _tabController;
+
+  void _handleTabChanged() {
+    final controller = _tabController;
+    if (controller == null) return;
+    if (!controller.indexIsChanging && _selectedIndex != controller.index) {
+      setState(() {
+        _selectedIndex = controller.index;
+      });
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _loadCategories();
+  }
+
+  Future<void> _loadCategories() async {
+    setState(() {
+      _isLoading = true;
+      _error = null;
+    });
+    try {
+      final cats = await _api.fetchFeeds();
+      final validCats = cats.where((cat) => cat.id.isNotEmpty).toList();
+      if (mounted) {
+        setState(() {
+          _categories = validCats;
+          _selectedIndex = _selectedIndex.clamp(0, validCats.length);
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() => _error = 'Ошибка загрузки');
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _isLoading = false);
+      } else {
+        _isLoading = false;
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _tabController?.removeListener(_handleTabChanged);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_isLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (_categories.isEmpty) {
+      return Center(
+        child: Text(_error ?? 'Нет данных'),
+      );
+    }
+
+    final initialIndex = _selectedIndex.clamp(0, _categories.length);
+
+    return DefaultTabController(
+      length: _categories.length + 1,
+      initialIndex: initialIndex,
+      child: Column(
+        children: [
+          Builder(
+            builder: (context) {
+              final controller = DefaultTabController.of(context);
+              if (_tabController != controller) {
+                _tabController?.removeListener(_handleTabChanged);
+                _tabController = controller;
+                _tabController?.addListener(_handleTabChanged);
+              }
+              if (controller != null && controller.index != initialIndex) {
+                controller.index = initialIndex;
+              }
+              return TabBar(
+                isScrollable: true,
+                tabAlignment: TabAlignment.start,
+                tabs: [
+                  const Tab(text: 'Все видео'),
+                  for (final cat in _categories) Tab(text: cat.name),
+                ],
+                onTap: (index) {
+                  if (_selectedIndex != index) {
+                    setState(() {
+                      _selectedIndex = index;
+                    });
+                  }
+                },
+              );
+            },
+          ),
+          Expanded(
+            child: TabBarView(
+              children: [
+                const VideoList(
+                  key: PageStorageKey('videos-all'),
+                ),
+                for (final cat in _categories)
+                  VideoList(
+                    key: PageStorageKey('videos-${cat.id}'),
+                    categoryId: cat.id,
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated API service and models for loading video feeds and items
- implement video list and detail screens mirroring the news experience with inline VK iframe playback
- expose the new video section from the home tab bar with an appropriate icon

## Testing
- flutter test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cce1084ec8832692e731f9b3eaa295