### PR TITLE
Fix iframe RegExp parsing

### DIFF
--- a/lib/features/video/video_article_view.dart
+++ b/lib/features/video/video_article_view.dart
@@ -304,9 +304,10 @@ class _MediaContent extends StatelessWidget {
 Uri? _extractVideoUri(String rawHtml) {
   final html = rawHtml.trim();
   if (html.isEmpty) return null;
-  final match =
-      RegExp(r'<iframe[^>]+src\s*=\s*["\']([^"\']+)["\']', caseSensitive: false)
-          .firstMatch(html);
+  final match = RegExp(
+    r"""<iframe[^>]+src\s*=\s*["']([^"']+)["']""",
+    caseSensitive: false,
+  ).firstMatch(html);
   if (match == null) return null;
   var src = match.group(1)?.trim();
   if (src == null || src.isEmpty) return null;


### PR DESCRIPTION
## Summary
- update the iframe source extraction to use a raw triple-quoted pattern that Dart accepts

## Testing
- `flutter analyze` *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cceae5c6648326b2989ce1c0531f66