### PR TITLE
Handle escaped iframe HTML in video extractor

### DIFF
--- a/lib/features/video/video_article_view.dart
+++ b/lib/features/video/video_article_view.dart
@@ -1,4 +1,5 @@
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_html/flutter_html.dart';
@@ -302,7 +303,7 @@ class _MediaContent extends StatelessWidget {
 }
 
 Uri? _extractVideoUri(String rawHtml) {
-  final html = rawHtml.trim();
+  final html = _unescapeHtml(rawHtml).trim();
   if (html.isEmpty) return null;
   final match = RegExp(
     r"""<iframe[^>]+src\s*=\s*["']([^"']+)["']""",
@@ -326,6 +327,32 @@ Uri? _extractVideoUri(String rawHtml) {
   }
   return uri;
 }
+
+String _unescapeHtml(String value) {
+  if (value.isEmpty) return value;
+  const entities = <MapEntry<String, String>>[
+    MapEntry('&amp;', '&'),
+    MapEntry('&lt;', '<'),
+    MapEntry('&gt;', '>'),
+    MapEntry('&quot;', '"'),
+    MapEntry('&#39;', "'"),
+    MapEntry('&apos;', "'"),
+  ];
+
+  var result = value;
+  var previous = '';
+  while (result != previous) {
+    previous = result;
+    for (final entry in entities) {
+      result = result.replaceAll(entry.key, entry.value);
+    }
+  }
+
+  return result;
+}
+
+@visibleForTesting
+Uri? extractVideoUriForTesting(String rawHtml) => _extractVideoUri(rawHtml);
 
 class _VideoIframePlayer extends StatefulWidget {
   const _VideoIframePlayer({required this.url});

--- a/test/features/video/video_article_view_test.dart
+++ b/test/features/video/video_article_view_test.dart
@@ -1,0 +1,13 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m_club/features/video/video_article_view.dart';
+
+void main() {
+  test('extractVideoUriForTesting decodes escaped iframe html', () {
+    const escapedIframe = '&lt;iframe src=&quot;https://example.com/embed&quot;&gt;';
+
+    final uri = extractVideoUriForTesting(escapedIframe);
+
+    expect(uri, isNotNull);
+    expect(uri.toString(), 'https://example.com/embed');
+  });
+}


### PR DESCRIPTION
## Summary
- HTML-unescape the raw iframe HTML before parsing so escaped embeds are detected
- Add a helper to decode common HTML entities used in backend iframe markup
- Expose a test-only wrapper and add a regression test for escaped iframe sources

## Testing
- flutter test *(fails: Flutter SDK is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cceefc911c832680af488d36ee79cc