### PR TITLE
Render video iframe HTML directly

### DIFF
--- a/test/features/video/video_article_view_test.dart
+++ b/test/features/video/video_article_view_test.dart
@@ -2,12 +2,12 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:m_club/features/video/video_article_view.dart';
 
 void main() {
-  test('extractVideoUriForTesting decodes escaped iframe html', () {
-    const escapedIframe = '&lt;iframe src=&quot;https://example.com/embed&quot;&gt;';
+  test('prepareVideoFrameHtmlForTesting decodes escaped iframe html', () {
+    const escapedIframe =
+        '&lt;iframe src=&quot;https://example.com/embed&quot;&gt;&lt;/iframe&gt;';
 
-    final uri = extractVideoUriForTesting(escapedIframe);
+    final html = prepareVideoFrameHtmlForTesting(escapedIframe);
 
-    expect(uri, isNotNull);
-    expect(uri.toString(), 'https://example.com/embed');
+    expect(html, '<iframe src="https://example.com/embed"></iframe>');
   });
 }


### PR DESCRIPTION
## Summary
- pass the raw iframe HTML from `videoFrame` into the video player instead of parsing only the src
- load the iframe HTML in the WebView via `loadHtmlString` with a minimal wrapper document
- update the HTML preparation helper and its unit test to reflect the new behaviour

## Testing
- Not run (flutter is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68ccf10c386c8326b9302e47311400e3