### PR TITLE
Enable autoplay for embedded video playback

### DIFF
--- a/lib/features/video/video_article_view.dart
+++ b/lib/features/video/video_article_view.dart
@@ -354,6 +354,7 @@ class _VideoIframePlayerState extends State<_VideoIframePlayer> {
     _controller = WebViewController()
       ..setJavaScriptMode(JavaScriptMode.unrestricted)
       ..setBackgroundColor(Colors.black)
+      ..setMediaPlaybackRequiresUserGesture(false)
       ..setNavigationDelegate(
         NavigationDelegate(
           onPageFinished: (_) {


### PR DESCRIPTION
## Summary
- allow the embedded WebView player to start media without requiring a user gesture so videos can autoplay

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ccf4a96b4c8326ab78464b18701c8c